### PR TITLE
chore: Removing deprecated methods given we are about to release a major version bump

### DIFF
--- a/docs/code/classes/types_app_client.ApplicationClient.md
+++ b/docs/code/classes/types_app_client.ApplicationClient.md
@@ -47,7 +47,6 @@ Application client - a class that wraps an ARC-0032 app spec and provides high p
 - [getBoxValue](types_app_client.ApplicationClient.md#getboxvalue)
 - [getBoxValueFromABIType](types_app_client.ApplicationClient.md#getboxvaluefromabitype)
 - [getBoxValues](types_app_client.ApplicationClient.md#getboxvalues)
-- [getBoxValuesAsABIType](types_app_client.ApplicationClient.md#getboxvaluesasabitype)
 - [getBoxValuesFromABIType](types_app_client.ApplicationClient.md#getboxvaluesfromabitype)
 - [getCallArgs](types_app_client.ApplicationClient.md#getcallargs)
 - [getGlobalState](types_app_client.ApplicationClient.md#getglobalstate)
@@ -413,7 +412,7 @@ The new error, or if there was no logic error or source map then the wrapped err
 
 #### Defined in
 
-[src/types/app-client.ts:806](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L806)
+[src/types/app-client.ts:801](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L801)
 
 ___
 
@@ -461,7 +460,7 @@ The ABI method for the given method
 
 #### Defined in
 
-[src/types/app-client.ts:765](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L765)
+[src/types/app-client.ts:760](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L760)
 
 ___
 
@@ -485,7 +484,7 @@ The ABI method params for the given method
 
 #### Defined in
 
-[src/types/app-client.ts:743](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L743)
+[src/types/app-client.ts:738](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L738)
 
 ___
 
@@ -504,7 +503,7 @@ The app reference, or if deployed using the `deploy` method, the app metadata to
 
 #### Defined in
 
-[src/types/app-client.ts:775](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L775)
+[src/types/app-client.ts:770](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L770)
 
 ___
 
@@ -600,31 +599,6 @@ The (name, value) pair of the boxes with values as raw byte arrays
 
 ___
 
-### getBoxValuesAsABIType
-
-▸ **getBoxValuesAsABIType**(`type`, `filter?`): `Promise`<{ `name`: [`BoxName`](../interfaces/types_app.BoxName.md) ; `value`: `ABIValue`  }[]\>
-
-**`Deprecated`**
-
-Use `getBoxValuesFromABIType` instead
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `type` | `ABIType` |
-| `filter?` | (`name`: [`BoxName`](../interfaces/types_app.BoxName.md)) => `boolean` |
-
-#### Returns
-
-`Promise`<{ `name`: [`BoxName`](../interfaces/types_app.BoxName.md) ; `value`: `ABIValue`  }[]\>
-
-#### Defined in
-
-[src/types/app-client.ts:709](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L709)
-
-___
-
 ### getBoxValuesFromABIType
 
 ▸ **getBoxValuesFromABIType**(`type`, `filter?`): `Promise`<{ `name`: [`BoxName`](../interfaces/types_app.BoxName.md) ; `value`: `ABIValue`  }[]\>
@@ -671,7 +645,7 @@ The call args ready to pass into an app call
 
 #### Defined in
 
-[src/types/app-client.ts:718](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L718)
+[src/types/app-client.ts:713](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L713)
 
 ___
 

--- a/docs/code/enums/types_app_spec.AVMType.md
+++ b/docs/code/enums/types_app_spec.AVMType.md
@@ -21,7 +21,7 @@ AVM data type
 
 #### Defined in
 
-[src/types/app-spec.ts:97](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L97)
+[src/types/app-spec.ts:96](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L96)
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 #### Defined in
 
-[src/types/app-spec.ts:96](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L96)
+[src/types/app-spec.ts:95](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L95)

--- a/docs/code/interfaces/types_app_spec.AppSources.md
+++ b/docs/code/interfaces/types_app_spec.AppSources.md
@@ -23,7 +23,7 @@ The TEAL source of the approval program
 
 #### Defined in
 
-[src/types/app-spec.ts:26](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L26)
+[src/types/app-spec.ts:25](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L25)
 
 ___
 
@@ -35,4 +35,4 @@ The TEAL source of the clear program
 
 #### Defined in
 
-[src/types/app-spec.ts:28](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L28)
+[src/types/app-spec.ts:27](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L27)

--- a/docs/code/interfaces/types_app_spec.AppSpec.md
+++ b/docs/code/interfaces/types_app_spec.AppSpec.md
@@ -27,7 +27,7 @@ The config of all BARE calls (i.e. non ABI calls with no args)
 
 #### Defined in
 
-[src/types/app-spec.ts:17](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L17)
+[src/types/app-spec.ts:16](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L16)
 
 ___
 
@@ -39,7 +39,7 @@ The ABI-0004 contract definition see https://github.com/algorandfoundation/ARCs/
 
 #### Defined in
 
-[src/types/app-spec.ts:11](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L11)
+[src/types/app-spec.ts:10](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L10)
 
 ___
 
@@ -51,7 +51,7 @@ Method call hints
 
 #### Defined in
 
-[src/types/app-spec.ts:7](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L7)
+[src/types/app-spec.ts:6](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L6)
 
 ___
 
@@ -63,7 +63,7 @@ The values that make up the local and global state
 
 #### Defined in
 
-[src/types/app-spec.ts:13](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L13)
+[src/types/app-spec.ts:12](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L12)
 
 ___
 
@@ -75,7 +75,7 @@ The TEAL source
 
 #### Defined in
 
-[src/types/app-spec.ts:9](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L9)
+[src/types/app-spec.ts:8](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L8)
 
 ___
 
@@ -87,4 +87,4 @@ The rolled-up schema allocation values for local and global state
 
 #### Defined in
 
-[src/types/app-spec.ts:15](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L15)
+[src/types/app-spec.ts:14](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L14)

--- a/docs/code/interfaces/types_app_spec.CallConfig.md
+++ b/docs/code/interfaces/types_app_spec.CallConfig.md
@@ -27,7 +27,7 @@ Clear state call config
 
 #### Defined in
 
-[src/types/app-spec.ts:48](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L48)
+[src/types/app-spec.ts:47](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L47)
 
 ___
 
@@ -39,7 +39,7 @@ Close out call config
 
 #### Defined in
 
-[src/types/app-spec.ts:46](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L46)
+[src/types/app-spec.ts:45](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L45)
 
 ___
 
@@ -51,7 +51,7 @@ Delete call config
 
 #### Defined in
 
-[src/types/app-spec.ts:52](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L52)
+[src/types/app-spec.ts:51](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L51)
 
 ___
 
@@ -63,7 +63,7 @@ NoOp call config
 
 #### Defined in
 
-[src/types/app-spec.ts:42](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L42)
+[src/types/app-spec.ts:41](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L41)
 
 ___
 
@@ -75,7 +75,7 @@ Opt-in call config
 
 #### Defined in
 
-[src/types/app-spec.ts:44](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L44)
+[src/types/app-spec.ts:43](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L43)
 
 ___
 
@@ -87,4 +87,4 @@ Update call config
 
 #### Defined in
 
-[src/types/app-spec.ts:50](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L50)
+[src/types/app-spec.ts:49](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L49)

--- a/docs/code/interfaces/types_app_spec.DeclaredSchemaValueSpec.md
+++ b/docs/code/interfaces/types_app_spec.DeclaredSchemaValueSpec.md
@@ -25,7 +25,7 @@ A description of the variable
 
 #### Defined in
 
-[src/types/app-spec.ts:107](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L107)
+[src/types/app-spec.ts:106](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L106)
 
 ___
 
@@ -37,7 +37,7 @@ The name of the key
 
 #### Defined in
 
-[src/types/app-spec.ts:105](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L105)
+[src/types/app-spec.ts:104](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L104)
 
 ___
 
@@ -49,7 +49,7 @@ Whether or not the value is set statically (at create time only) or dynamically
 
 #### Defined in
 
-[src/types/app-spec.ts:109](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L109)
+[src/types/app-spec.ts:108](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L108)
 
 ___
 
@@ -61,4 +61,4 @@ The type of value
 
 #### Defined in
 
-[src/types/app-spec.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L103)
+[src/types/app-spec.ts:102](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L102)

--- a/docs/code/interfaces/types_app_spec.DefaultArgument.md
+++ b/docs/code/interfaces/types_app_spec.DefaultArgument.md
@@ -23,7 +23,7 @@ The name or value corresponding to the source
 
 #### Defined in
 
-[src/types/app-spec.ts:91](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L91)
+[src/types/app-spec.ts:90](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L90)
 
 ___
 
@@ -39,4 +39,4 @@ The source of the default argument value:
 
 #### Defined in
 
-[src/types/app-spec.ts:89](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L89)
+[src/types/app-spec.ts:88](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L88)

--- a/docs/code/interfaces/types_app_spec.Hint.md
+++ b/docs/code/interfaces/types_app_spec.Hint.md
@@ -23,7 +23,7 @@ Hint information for a given method call to allow client generation
 
 #### Defined in
 
-[src/types/app-spec.ts:61](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L61)
+[src/types/app-spec.ts:60](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L60)
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 #### Defined in
 
-[src/types/app-spec.ts:60](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L60)
+[src/types/app-spec.ts:59](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L59)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[src/types/app-spec.ts:59](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L59)
+[src/types/app-spec.ts:58](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L58)
 
 ___
 
@@ -55,4 +55,4 @@ Any user-defined struct/tuple types used in the method call, keyed by parameter 
 
 #### Defined in
 
-[src/types/app-spec.ts:58](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L58)
+[src/types/app-spec.ts:57](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L57)

--- a/docs/code/interfaces/types_app_spec.ReservedSchemaValueSpec.md
+++ b/docs/code/interfaces/types_app_spec.ReservedSchemaValueSpec.md
@@ -24,7 +24,7 @@ The description of the reserved storage space
 
 #### Defined in
 
-[src/types/app-spec.ts:117](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L117)
+[src/types/app-spec.ts:116](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L116)
 
 ___
 
@@ -36,7 +36,7 @@ The maximum number of slots to reserve
 
 #### Defined in
 
-[src/types/app-spec.ts:119](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L119)
+[src/types/app-spec.ts:118](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L118)
 
 ___
 
@@ -48,4 +48,4 @@ The type of value
 
 #### Defined in
 
-[src/types/app-spec.ts:115](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L115)
+[src/types/app-spec.ts:114](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L114)

--- a/docs/code/interfaces/types_app_spec.Schema.md
+++ b/docs/code/interfaces/types_app_spec.Schema.md
@@ -23,7 +23,7 @@ Declared storage schema
 
 #### Defined in
 
-[src/types/app-spec.ts:133](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L133)
+[src/types/app-spec.ts:132](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L132)
 
 ___
 
@@ -35,4 +35,4 @@ Reserved storage schema
 
 #### Defined in
 
-[src/types/app-spec.ts:135](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L135)
+[src/types/app-spec.ts:134](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L134)

--- a/docs/code/interfaces/types_app_spec.SchemaSpec.md
+++ b/docs/code/interfaces/types_app_spec.SchemaSpec.md
@@ -23,7 +23,7 @@ The global storage schema
 
 #### Defined in
 
-[src/types/app-spec.ts:127](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L127)
+[src/types/app-spec.ts:126](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L126)
 
 ___
 
@@ -35,4 +35,4 @@ The local storage schema
 
 #### Defined in
 
-[src/types/app-spec.ts:125](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L125)
+[src/types/app-spec.ts:124](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L124)

--- a/docs/code/interfaces/types_app_spec.StateSchemaSpec.md
+++ b/docs/code/interfaces/types_app_spec.StateSchemaSpec.md
@@ -23,7 +23,7 @@ Global storage spec
 
 #### Defined in
 
-[src/types/app-spec.ts:141](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L141)
+[src/types/app-spec.ts:140](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L140)
 
 ___
 
@@ -35,4 +35,4 @@ Local storage spec
 
 #### Defined in
 
-[src/types/app-spec.ts:143](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L143)
+[src/types/app-spec.ts:142](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L142)

--- a/docs/code/interfaces/types_app_spec.Struct.md
+++ b/docs/code/interfaces/types_app_spec.Struct.md
@@ -23,7 +23,7 @@ The elements (in order) that make up the struct/tuple
 
 #### Defined in
 
-[src/types/app-spec.ts:78](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L78)
+[src/types/app-spec.ts:77](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L77)
 
 ___
 
@@ -35,4 +35,4 @@ The name of the type
 
 #### Defined in
 
-[src/types/app-spec.ts:76](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L76)
+[src/types/app-spec.ts:75](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L75)

--- a/docs/code/modules/index.md
+++ b/docs/code/modules/index.md
@@ -39,12 +39,10 @@
 - [getAppBoxValues](index.md#getappboxvalues)
 - [getAppBoxValuesFromABIType](index.md#getappboxvaluesfromabitype)
 - [getAppById](index.md#getappbyid)
-- [getAppByIndex](index.md#getappbyindex)
 - [getAppClient](index.md#getappclient)
 - [getAppDeploymentTransactionNote](index.md#getappdeploymenttransactionnote)
 - [getAppGlobalState](index.md#getappglobalstate)
 - [getAppLocalState](index.md#getapplocalstate)
-- [getApplicationClient](index.md#getapplicationclient)
 - [getAtomicTransactionComposerTransactions](index.md#getatomictransactioncomposertransactions)
 - [getBoxReference](index.md#getboxreference)
 - [getCreatorAppsByName](index.md#getcreatorappsbyname)
@@ -190,7 +188,7 @@ The information about the compiled file
 
 #### Defined in
 
-[src/app.ts:624](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app.ts#L624)
+[src/app.ts:621](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app.ts#L621)
 
 ___
 
@@ -416,7 +414,7 @@ The encoded ABI method spec e.g. `method_name(uint64,string)string`
 
 #### Defined in
 
-[src/app.ts:640](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app.ts#L640)
+[src/app.ts:637](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app.ts#L637)
 
 ___
 
@@ -930,31 +928,6 @@ The data about the app
 
 ___
 
-### getAppByIndex
-
-▸ **getAppByIndex**(`appId`, `algod`): `Promise`<[`ApplicationResponse`](../interfaces/types_algod.ApplicationResponse.md)\>
-
-**`Deprecated`**
-
-Use `algokit.getAppById` instead.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `appId` | `number` |
-| `algod` | `default` |
-
-#### Returns
-
-`Promise`<[`ApplicationResponse`](../interfaces/types_algod.ApplicationResponse.md)\>
-
-#### Defined in
-
-[src/app.ts:610](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app.ts#L610)
-
-___
-
 ### getAppClient
 
 ▸ **getAppClient**(`appDetails`, `algod`): [`ApplicationClient`](../classes/types_app_client.ApplicationClient.md)
@@ -976,7 +949,7 @@ The application client
 
 #### Defined in
 
-[src/app-client.ts:15](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app-client.ts#L15)
+[src/app-client.ts:10](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app-client.ts#L10)
 
 ___
 
@@ -1052,31 +1025,6 @@ The current local state for the given (app, account) combination
 #### Defined in
 
 [src/app.ts:400](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app.ts#L400)
-
-___
-
-### getApplicationClient
-
-▸ **getApplicationClient**(`appDetails`, `algod`): [`ApplicationClient`](../classes/types_app_client.ApplicationClient.md)
-
-**`Deprecated`**
-
-Use `algokit.getAppClient`
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `appDetails` | [`AppSpecAppDetails`](types_app_client.md#appspecappdetails) |
-| `algod` | `default` |
-
-#### Returns
-
-[`ApplicationClient`](../classes/types_app_client.ApplicationClient.md)
-
-#### Defined in
-
-[src/app-client.ts:15](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app-client.ts#L15)
 
 ___
 

--- a/docs/code/modules/types_app_spec.md
+++ b/docs/code/modules/types_app_spec.md
@@ -31,10 +31,6 @@
 - [StateSchema](types_app_spec.md#stateschema)
 - [StructElement](types_app_spec.md#structelement)
 
-### Functions
-
-- [getABISignature](types_app_spec.md#getabisignature)
-
 ## Type Aliases
 
 ### ABIType
@@ -45,7 +41,7 @@ The string name of an ABI type
 
 #### Defined in
 
-[src/types/app-spec.ts:68](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L68)
+[src/types/app-spec.ts:67](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L67)
 
 ___
 
@@ -61,7 +57,7 @@ The various call configs:
 
 #### Defined in
 
-[src/types/app-spec.ts:37](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L37)
+[src/types/app-spec.ts:36](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L36)
 
 ___
 
@@ -73,7 +69,7 @@ The name of a field
 
 #### Defined in
 
-[src/types/app-spec.ts:65](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L65)
+[src/types/app-spec.ts:64](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L64)
 
 ___
 
@@ -85,7 +81,7 @@ A lookup of encoded method call spec to hint
 
 #### Defined in
 
-[src/types/app-spec.ts:21](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L21)
+[src/types/app-spec.ts:20](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L20)
 
 ___
 
@@ -104,7 +100,7 @@ Schema spec summary for global or local storage
 
 #### Defined in
 
-[src/types/app-spec.ts:147](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L147)
+[src/types/app-spec.ts:146](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L146)
 
 ___
 
@@ -116,28 +112,4 @@ The elements of the struct/tuple: `FieldName`, `ABIType`
 
 #### Defined in
 
-[src/types/app-spec.ts:71](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L71)
-
-## Functions
-
-### getABISignature
-
-▸ **getABISignature**(`method`): `string`
-
-**`Deprecated`**
-
-Use `algokit.getABIMethodSignature` instead
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `method` | `ABIMethodParams` \| `ABIMethod` |
-
-#### Returns
-
-`string`
-
-#### Defined in
-
-[src/app.ts:640](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app.ts#L640)
+[src/types/app-spec.ts:70](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L70)

--- a/src/app-client.ts
+++ b/src/app-client.ts
@@ -2,11 +2,6 @@ import { Algodv2 } from 'algosdk'
 import { ApplicationClient, AppSpecAppDetails } from './types/app-client'
 
 /**
- * @deprecated Use `algokit.getAppClient`
- */
-export const getApplicationClient = getAppClient
-
-/**
  * Create a new ApplicationClient instance
  * @param appDetails The details of the app
  * @param algod An algod instance

--- a/src/app.ts
+++ b/src/app.ts
@@ -611,9 +611,6 @@ export async function getAppById(appId: number, algod: Algodv2) {
   return (await algod.getApplicationByID(appId).do()) as ApplicationResponse
 }
 
-/** @deprecated Use `algokit.getAppById` instead. */
-export const getAppByIndex = getAppById
-
 /**
  * Compiles the given TEAL using algod and returns the result, including source map.
  *

--- a/src/types/app-client.ts
+++ b/src/types/app-client.ts
@@ -705,11 +705,6 @@ export class ApplicationClient {
     )
   }
 
-  /** @deprecated Use `getBoxValuesFromABIType` instead */
-  async getBoxValuesAsABIType(type: ABIType, filter?: (name: BoxName) => boolean): Promise<{ name: BoxName; value: ABIValue }[]> {
-    return this.getBoxValuesFromABIType(type, filter)
-  }
-
   /**
    * Returns the arguments for an app call for the given ABI method or raw method specification.
    * @param args The call args specific to this application client

--- a/src/types/app-spec.ts
+++ b/src/types/app-spec.ts
@@ -1,5 +1,4 @@
 import { ABIContractParams } from 'algosdk'
-import { getABIMethodSignature } from '../app'
 
 /** An ARC-0032 Application Specification see https://github.com/algorandfoundation/ARCs/pull/150 */
 export interface AppSpec {
@@ -150,6 +149,3 @@ export type StateSchema = {
   /** Number of byte slots */
   num_byte_slices: number
 }
-
-/** @deprecated Use `algokit.getABIMethodSignature` instead */
-export const getABISignature = getABIMethodSignature


### PR DESCRIPTION
BREAKING CHANGE: The following deprecated methods have been removed: `getApplicationClient`, `getAppByIndex`, `appClient.getBoxValuesAsABIType`, `getABISignature`