### PR TITLE
deps: Dependency updates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,7 @@ jobs:
   pull_request:
     uses: makerxstudio/shared-config/.github/workflows/node-ci.yml@main
     with:
+      node-version: 18.x
       working-directory: ./
       run-commit-lint: true
       run-build: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     name: Continuous Integration
     uses: makerxstudio/shared-config/.github/workflows/node-ci.yml@main
     with:
+      node-version: 18.x
       run-commit-lint: true
       pre-test-script: |
         pipx install algokit
@@ -49,6 +50,7 @@ jobs:
       - ci
       - check_docs
     with:
+      node-version: 18.x
       build-path: dist
       artifact-name: package
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "tiny-invariant": "^1.3.1",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
-        "typedoc": "^0.24.8",
+        "typedoc": "^0.25.0",
         "typedoc-plugin-markdown": "^3.15.4",
         "typescript": "^5.1.3",
         "uuid": "^9.0.0"
@@ -13805,24 +13805,24 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
-      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.0.tgz",
+      "integrity": "sha512-FvCYWhO1n5jACE0C32qg6b3dSfQ8f2VzExnnRboowHtqUD6ARzM2r8YJeZFYXhcm2hI4C2oCRDgNPk/yaQUN9g==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.3",
         "shiki": "^0.14.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 14.14"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x"
       }
     },
     "node_modules/typedoc-plugin-markdown": {
@@ -13859,9 +13859,9 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.2.tgz",
-      "integrity": "sha512-PZOT9g5v2ojiTL7r1xF6plNHLtOeTpSlDI007As2NlA2aYBMfVom17yqa6QzhmDP8QOhn7LjHTg7DFCVSSa6yg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": ">=16.0"
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "algosdk": "^2.5.0"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "tiny-invariant": "^1.3.1",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
-    "typedoc": "^0.24.8",
+    "typedoc": "^0.25.0",
     "typedoc-plugin-markdown": "^3.15.4",
     "typescript": "^5.1.3",
     "uuid": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Algorand Foundation",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "type": "module",
   "main": "./cjs/index.js",


### PR DESCRIPTION
Update the following dependencies:
- conventional-changelog-conventionalcommits
- typedoc
- semantic-release
- typescript

Update the minimum desired node version to 18.0