### PR TITLE
build(dev-deps): revert conventional-changelog-conventionalcommits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/uuid": "^9.0.2",
         "algosdk": "^2.5.0",
         "better-npm-audit": "^3.7.3",
-        "conventional-changelog-conventionalcommits": "^7.0.1",
+        "conventional-changelog-conventionalcommits": "6.1.0",
         "copyfiles": "^2.4.1",
         "dotenv-cli": "^7.3.0",
         "eslint": "^8.47.0",
@@ -717,18 +717,6 @@
       },
       "engines": {
         "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
-      "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
-      "dev": true,
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -3769,15 +3757,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.1.tgz",
-      "integrity": "sha512-VfFJxBmi+LYXeb4pIfZGbuaFCpWZh0qXbUAKP/s6B8tigV6R4D8j5PDlTtMMWawa7+DcNySVoF7kPWz0EMYuCQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
+      "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/uuid": "^9.0.2",
     "algosdk": "^2.5.0",
     "better-npm-audit": "^3.7.3",
-    "conventional-changelog-conventionalcommits": "^7.0.1",
+    "conventional-changelog-conventionalcommits": "6.1.0",
     "copyfiles": "^2.4.1",
     "dotenv-cli": "^7.3.0",
     "eslint": "^8.47.0",


### PR DESCRIPTION
7.0.1 of `conventional-changelog-conventionalcommits` breaks the semantic release process, reverting back to the previous working version.