### PR TITLE
fix: types export in build artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
       "import": "./esm/index.js",
       "require": "./cjs/index.js"
     },
+    "./types/*": {
+      "import": "./esm/types/*.js",
+      "require": "./cjs/types/*.js"
+    },
     "./testing": {
       "import": "./esm/testing/index.js",
       "require": "./cjs/testing/index.js"


### PR DESCRIPTION
BREAKING CHANGE: adding explicit types export into package json for correct `types` folder resolution in typescript.

Migration guide:

- Make sure to set `moduleResolution` to `node16` or `nodenext` for correct module resolution
