### PR TITLE
docs: Remove missing algod type from the docs

### DIFF
--- a/docs/capabilities/transaction.md
+++ b/docs/capabilities/transaction.md
@@ -23,7 +23,7 @@ All AlgoKit Utils functions that prepare and/or send a transaction will generall
 It consists of two properties:
 
 - `transaction`: An `algosdk.Transaction` object that is either ready to send or represents the transaction that was sent
-- `confirmation` (optional): A [`PendingTransactionResponse`](../code/interfaces/types_algod.PendingTransactionResponse.md) object, which is a type-safe wrapper of the return from the algod pending transaction API noting that it will only be returned if the transaction was able to be confirmed (so won't represent a "pending" transaction)
+- `confirmation` (optional): An `algosdk.modelsv2.PendingTransactionResponse` object, which is a type-safe wrapper of the return from the algod pending transaction API noting that it will only be returned if the transaction was able to be confirmed (so won't represent a "pending" transaction)
 
 A useful pattern to use to access these properties is destructuring, e.g.:
 


### PR DESCRIPTION
To fix the other warnings encountered in https://github.com/algorand/docs/pull/1149 we'll need to either:
- Have the `docs` repo detect a TypeScript link and generate an absolute path to this GitHub repo.
- Use absolute paths inside our docs for the TypeScript links.