### PR TITLE
chore: bump algosdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "buffer": "^6.0.3"
   },
   "peerDependencies": {
-    "algosdk": "^2.5.0"
+    "algosdk": "^2.7.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.7.1",


### PR DESCRIPTION
## Proposed Changes
Update min version of algosdk peer dependency to `2.7.0`, as per https://github.com/algorandfoundation/algokit-utils-ts/issues/158