### PR TITLE
fix: add an isomorphic __dirname implementation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,14 @@
         // The easiest solution for now, is to only use the default export.
         "message": "Only use the default export in 'algosdk'. See rule comment for details",
         "selector": "ImportDeclaration[source.value=\"algosdk\"] ImportSpecifier"
+      },
+      {
+        "message": "__dirname cannot be used in ESM modules. Use a shim instead.",
+        "selector": "Identifier[name=\"__dirname\"]"
+      },
+      {
+        "message": "__filename cannot be used in ESM modules. Use a shim instead.",
+        "selector": "Identifier[name=\"__filename\"]"
       }
     ]
   },

--- a/docs/code/classes/types_config.UpdatableConfig.md
+++ b/docs/code/classes/types_config.UpdatableConfig.md
@@ -48,7 +48,7 @@ Updatable AlgoKit config
 
 #### Defined in
 
-[src/types/config.ts:76](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L76)
+[src/types/config.ts:82](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L82)
 
 ## Properties
 
@@ -58,7 +58,7 @@ Updatable AlgoKit config
 
 #### Defined in
 
-[src/types/config.ts:23](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L23)
+[src/types/config.ts:29](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L29)
 
 ## Accessors
 
@@ -76,7 +76,7 @@ Readonly.debug
 
 #### Defined in
 
-[src/types/config.ts:29](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L29)
+[src/types/config.ts:35](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L35)
 
 ___
 
@@ -94,7 +94,7 @@ Readonly.logger
 
 #### Defined in
 
-[src/types/config.ts:25](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L25)
+[src/types/config.ts:31](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L31)
 
 ___
 
@@ -112,7 +112,7 @@ Readonly.maxSearchDepth
 
 #### Defined in
 
-[src/types/config.ts:45](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L45)
+[src/types/config.ts:51](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L51)
 
 ___
 
@@ -130,7 +130,7 @@ Readonly.projectRoot
 
 #### Defined in
 
-[src/types/config.ts:33](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L33)
+[src/types/config.ts:39](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L39)
 
 ___
 
@@ -148,7 +148,7 @@ Readonly.traceAll
 
 #### Defined in
 
-[src/types/config.ts:37](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L37)
+[src/types/config.ts:43](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L43)
 
 ___
 
@@ -166,7 +166,7 @@ Readonly.traceBufferSizeMb
 
 #### Defined in
 
-[src/types/config.ts:41](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L41)
+[src/types/config.ts:47](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L47)
 
 ## Methods
 
@@ -188,7 +188,7 @@ Update the AlgoKit configuration with your own configuration settings
 
 #### Defined in
 
-[src/types/config.ts:106](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L106)
+[src/types/config.ts:112](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L112)
 
 ___
 
@@ -204,7 +204,7 @@ Configures the project root by searching for a specific file within a depth limi
 
 #### Defined in
 
-[src/types/config.ts:91](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L91)
+[src/types/config.ts:97](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L97)
 
 ___
 
@@ -228,7 +228,7 @@ The requested logger
 
 #### Defined in
 
-[src/types/config.ts:54](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L54)
+[src/types/config.ts:60](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L60)
 
 ___
 
@@ -250,4 +250,4 @@ Temporarily run with debug set to true.
 
 #### Defined in
 
-[src/types/config.ts:66](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L66)
+[src/types/config.ts:72](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L72)

--- a/docs/code/interfaces/types_config.Config.md
+++ b/docs/code/interfaces/types_config.Config.md
@@ -27,7 +27,7 @@ Whether or not debug mode is enabled
 
 #### Defined in
 
-[src/types/config.ts:10](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L10)
+[src/types/config.ts:16](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L16)
 
 ___
 
@@ -39,7 +39,7 @@ Logger
 
 #### Defined in
 
-[src/types/config.ts:8](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L8)
+[src/types/config.ts:14](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L14)
 
 ___
 
@@ -51,7 +51,7 @@ The maximum depth to search for a specific file
 
 #### Defined in
 
-[src/types/config.ts:18](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L18)
+[src/types/config.ts:24](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L24)
 
 ___
 
@@ -63,7 +63,7 @@ The path to the project root directory
 
 #### Defined in
 
-[src/types/config.ts:12](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L12)
+[src/types/config.ts:18](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L18)
 
 ___
 
@@ -75,7 +75,7 @@ Indicates whether to trace all operations
 
 #### Defined in
 
-[src/types/config.ts:14](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L14)
+[src/types/config.ts:20](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L20)
 
 ___
 
@@ -87,4 +87,4 @@ The size of the trace buffer in megabytes
 
 #### Defined in
 
-[src/types/config.ts:16](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L16)
+[src/types/config.ts:22](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L22)

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -20,7 +20,7 @@ const config: Config.InitialOptions = {
           before: [
             {
               path: 'ts-jest-mock-import-meta',
-              options: { metaObjectReplacement: { url: 'ignore' } },
+              options: { metaObjectReplacement: { url: 'unreachable' } },
             },
           ],
         },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,10 +9,21 @@ const config: Config.InitialOptions = {
   setupFiles: ['<rootDir>/tests/setup.ts'],
   moduleDirectories: ['node_modules', 'src'],
   transform: {
-    '<regex_match_files>': [
+    '^.+\\.ts?$': [
       'ts-jest',
       {
         tsconfig: 'tsconfig.test.json',
+        diagnostics: {
+          ignoreCodes: [1343],
+        },
+        astTransformers: {
+          before: [
+            {
+              path: 'ts-jest-mock-import-meta',
+              options: { metaObjectReplacement: { url: 'ignore' } },
+            },
+          ],
+        },
       },
     ],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "jest-fetch-mock": "^3.0.3",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.0.2",
+        "replace-in-files-cli": "^2.2.0",
         "rimraf": "^5.0.1",
         "semantic-release": "^21.0.9",
         "tiny-invariant": "^1.3.1",
@@ -6562,6 +6563,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
+    },
     "node_modules/is-unicode-supported": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
@@ -12418,6 +12425,278 @@
         "node": ">=14"
       }
     },
+    "node_modules/replace-in-files-cli": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/replace-in-files-cli/-/replace-in-files-cli-2.2.0.tgz",
+      "integrity": "sha512-EI2Psum9Ay9y2IDWx36+hOvn+BX6LdQ8HXZ06L32obGrJb9w7YDMTywIQgysOXwQo5MsORtIA4l/g25r2Cp1gA==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "globby": "^12.0.2",
+        "meow": "^10.1.1",
+        "normalize-path": "^3.0.0",
+        "write-file-atomic": "^3.0.3"
+      },
+      "bin": {
+        "replace-in-files": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/array-union": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
+      "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/camelcase-keys": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
+      "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.3.0",
+        "map-obj": "^4.1.0",
+        "quick-lru": "^5.1.1",
+        "type-fest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/decamelize": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+      "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/globby": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-12.2.0.tgz",
+      "integrity": "sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^3.0.1",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.7",
+        "ignore": "^5.1.9",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/meow": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
+      "integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.2",
+        "camelcase-keys": "^7.0.0",
+        "decamelize": "^5.0.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.2",
+        "read-pkg-up": "^8.0.0",
+        "redent": "^4.0.0",
+        "trim-newlines": "^4.0.2",
+        "type-fest": "^1.2.2",
+        "yargs-parser": "^20.2.9"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/read-pkg": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+      "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/read-pkg-up": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+      "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0",
+        "read-pkg": "^6.0.0",
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/redent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^5.0.0",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/strip-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/trim-newlines": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
+      "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace-in-files-cli/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -14119,6 +14398,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
       }
     },
     "node_modules/typedoc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "semantic-release": "^21.0.9",
         "tiny-invariant": "^1.3.1",
         "ts-jest": "^29.1.0",
+        "ts-jest-mock-import-meta": "^1.1.0",
         "ts-node": "^10.9.1",
         "tsc-alias": "^1.8.8",
         "typedoc": "^0.25.4",
@@ -13915,6 +13916,15 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-jest-mock-import-meta": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ts-jest-mock-import-meta/-/ts-jest-mock-import-meta-1.1.0.tgz",
+      "integrity": "sha512-PTmdWGbDZOPh8vyZUmCTK5PjeD2X3YO25MQPTbm0lMlNFigUDwz3opwXOlsrgD0i5u/MpDX0gdZKoVONxVjVEw==",
+      "dev": true,
+      "peerDependencies": {
+        "ts-jest": ">=20.0.0"
       }
     },
     "node_modules/ts-jest/node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "semantic-release": "^21.0.9",
     "tiny-invariant": "^1.3.1",
     "ts-jest": "^29.1.0",
+    "ts-jest-mock-import-meta": "^1.1.0",
     "ts-node": "^10.9.1",
     "tsc-alias": "^1.8.8",
     "typedoc": "^0.25.4",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "build": "run-s build:*",
     "build:0-clean": "rimraf dist coverage",
-    "build:1-compile-cjs": "tsc -p tsconfig.cjs.json",
+    "build:1-compile-cjs": "tsc -p tsconfig.cjs.json && replace-in-files --string '(import.meta.url)' --replacement '(\"unreachable\")' ./dist/cjs/**/*.js",
     "build:2-compile-esm": "tsc -p tsconfig.esm.json && tsc-alias -p tsconfig.esm.json && cpy package.esm.json dist/esm --rename=package.json",
     "build:3-copy-pkg-json": "npx --yes @makerx/ts-toolkit@latest copy-package-json --main ./cjs/index.js --types ./types/index.d.ts --custom-sections exports typesVersions module",
     "build:4-copy-readme": "cpy README.md dist",
@@ -102,6 +102,7 @@
     "jest-fetch-mock": "^3.0.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.2",
+    "replace-in-files-cli": "^2.2.0",
     "rimraf": "^5.0.1",
     "semantic-release": "^21.0.9",
     "tiny-invariant": "^1.3.1",

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,12 @@
 import { existsSync } from 'fs'
 import { dirname, resolve } from 'path'
-import { consoleLogger, Logger, nullLogger } from './logging'
+import { fileURLToPath } from 'url'
+import { Logger, consoleLogger, nullLogger } from './logging'
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: Unreachable code error
+// eslint-disable-next-line no-restricted-syntax
+const _dirname = typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url))
 
 /** The AlgoKit configuration type */
 export interface Config {
@@ -89,7 +95,7 @@ export class UpdatableConfig implements Readonly<Config> {
    * Configures the project root by searching for a specific file within a depth limit.
    */
   private configureProjectRoot() {
-    let currentPath = resolve(__dirname)
+    let currentPath = resolve(_dirname)
     for (let i = 0; i < this.config.maxSearchDepth; i++) {
       if (existsSync(`${currentPath}/.algokit.toml`)) {
         this.config.projectRoot = currentPath

--- a/tests/example-contracts/testing-app/contract.ts
+++ b/tests/example-contracts/testing-app/contract.ts
@@ -1,12 +1,18 @@
 import { readFile } from 'fs/promises'
-import path from 'path'
+import path, { dirname } from 'path'
+import { fileURLToPath } from 'url'
 import { encodeTransactionNote, replaceDeployTimeControlParams } from '../../../src'
 import { APP_DEPLOY_NOTE_DAPP, AppDeployMetadata, OnSchemaBreak, OnUpdate } from '../../../src/types/app'
 import { AppSpec } from '../../../src/types/app-spec'
 import { Arc2TransactionNote, SendTransactionFrom } from '../../../src/types/transaction'
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: Unreachable code error
+// eslint-disable-next-line no-restricted-syntax
+const _dirname = typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url))
+
 export const getTestingAppContract = async () => {
-  const appSpecFile = await readFile(path.join(__dirname, 'application.json'), 'utf-8')
+  const appSpecFile = await readFile(path.join(_dirname, 'application.json'), 'utf-8')
   const appSpec = JSON.parse(appSpecFile) as AppSpec
 
   return {


### PR DESCRIPTION
Fixes a `ReferenceError: __dirname is not defined in ES module scope` when using `utils-ts` in an ESM project.

This is a temporary fix to solve the issue, however the longer term solution is to move to something like `rollup` or `tsup` where we can inject shims.