### PR TITLE
fix: lazy loading all node specific dependencies

### DIFF
--- a/docs/code/classes/types_config.UpdatableConfig.md
+++ b/docs/code/classes/types_config.UpdatableConfig.md
@@ -48,7 +48,7 @@ Updatable AlgoKit config
 
 #### Defined in
 
-[src/types/config.ts:88](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L88)
+[src/types/config.ts:75](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L75)
 
 ## Properties
 
@@ -58,7 +58,7 @@ Updatable AlgoKit config
 
 #### Defined in
 
-[src/types/config.ts:35](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L35)
+[src/types/config.ts:22](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L22)
 
 ## Accessors
 
@@ -76,7 +76,7 @@ Readonly.debug
 
 #### Defined in
 
-[src/types/config.ts:41](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L41)
+[src/types/config.ts:28](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L28)
 
 ___
 
@@ -94,7 +94,7 @@ Readonly.logger
 
 #### Defined in
 
-[src/types/config.ts:37](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L37)
+[src/types/config.ts:24](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L24)
 
 ___
 
@@ -112,7 +112,7 @@ Readonly.maxSearchDepth
 
 #### Defined in
 
-[src/types/config.ts:57](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L57)
+[src/types/config.ts:44](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L44)
 
 ___
 
@@ -130,7 +130,7 @@ Readonly.projectRoot
 
 #### Defined in
 
-[src/types/config.ts:45](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L45)
+[src/types/config.ts:32](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L32)
 
 ___
 
@@ -148,7 +148,7 @@ Readonly.traceAll
 
 #### Defined in
 
-[src/types/config.ts:49](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L49)
+[src/types/config.ts:36](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L36)
 
 ___
 
@@ -166,7 +166,7 @@ Readonly.traceBufferSizeMb
 
 #### Defined in
 
-[src/types/config.ts:53](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L53)
+[src/types/config.ts:40](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L40)
 
 ## Methods
 
@@ -188,7 +188,7 @@ Update the AlgoKit configuration with your own configuration settings
 
 #### Defined in
 
-[src/types/config.ts:138](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L138)
+[src/types/config.ts:131](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L131)
 
 ___
 
@@ -205,7 +205,7 @@ This is only supported in a Node environment.
 
 #### Defined in
 
-[src/types/config.ts:107](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L107)
+[src/types/config.ts:94](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L94)
 
 ___
 
@@ -229,7 +229,7 @@ The requested logger
 
 #### Defined in
 
-[src/types/config.ts:66](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L66)
+[src/types/config.ts:53](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L53)
 
 ___
 
@@ -251,4 +251,4 @@ Temporarily run with debug set to true.
 
 #### Defined in
 
-[src/types/config.ts:78](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L78)
+[src/types/config.ts:65](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L65)

--- a/docs/code/classes/types_config.UpdatableConfig.md
+++ b/docs/code/classes/types_config.UpdatableConfig.md
@@ -48,7 +48,7 @@ Updatable AlgoKit config
 
 #### Defined in
 
-[src/types/config.ts:77](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L77)
+[src/types/config.ts:88](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L88)
 
 ## Properties
 
@@ -58,7 +58,7 @@ Updatable AlgoKit config
 
 #### Defined in
 
-[src/types/config.ts:24](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L24)
+[src/types/config.ts:35](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L35)
 
 ## Accessors
 
@@ -76,7 +76,7 @@ Readonly.debug
 
 #### Defined in
 
-[src/types/config.ts:30](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L30)
+[src/types/config.ts:41](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L41)
 
 ___
 
@@ -94,7 +94,7 @@ Readonly.logger
 
 #### Defined in
 
-[src/types/config.ts:26](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L26)
+[src/types/config.ts:37](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L37)
 
 ___
 
@@ -112,7 +112,7 @@ Readonly.maxSearchDepth
 
 #### Defined in
 
-[src/types/config.ts:46](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L46)
+[src/types/config.ts:57](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L57)
 
 ___
 
@@ -130,7 +130,7 @@ Readonly.projectRoot
 
 #### Defined in
 
-[src/types/config.ts:34](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L34)
+[src/types/config.ts:45](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L45)
 
 ___
 
@@ -148,7 +148,7 @@ Readonly.traceAll
 
 #### Defined in
 
-[src/types/config.ts:38](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L38)
+[src/types/config.ts:49](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L49)
 
 ___
 
@@ -166,7 +166,7 @@ Readonly.traceBufferSizeMb
 
 #### Defined in
 
-[src/types/config.ts:42](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L42)
+[src/types/config.ts:53](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L53)
 
 ## Methods
 
@@ -188,24 +188,24 @@ Update the AlgoKit configuration with your own configuration settings
 
 #### Defined in
 
-[src/types/config.ts:118](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L118)
+[src/types/config.ts:138](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L138)
 
 ___
 
 ### configureProjectRoot
 
-▸ **configureProjectRoot**(): `void`
+▸ **configureProjectRoot**(): `Promise`\<`void`\>
 
 Configures the project root by searching for a specific file within a depth limit.
 This is only supported in a Node environment.
 
 #### Returns
 
-`void`
+`Promise`\<`void`\>
 
 #### Defined in
 
-[src/types/config.ts:93](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L93)
+[src/types/config.ts:107](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L107)
 
 ___
 
@@ -229,7 +229,7 @@ The requested logger
 
 #### Defined in
 
-[src/types/config.ts:55](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L55)
+[src/types/config.ts:66](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L66)
 
 ___
 
@@ -251,4 +251,4 @@ Temporarily run with debug set to true.
 
 #### Defined in
 
-[src/types/config.ts:67](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L67)
+[src/types/config.ts:78](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L78)

--- a/docs/code/classes/types_config.UpdatableConfig.md
+++ b/docs/code/classes/types_config.UpdatableConfig.md
@@ -188,7 +188,7 @@ Update the AlgoKit configuration with your own configuration settings
 
 #### Defined in
 
-[src/types/config.ts:131](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L131)
+[src/types/config.ts:127](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L127)
 
 ___
 

--- a/docs/code/interfaces/types_config.Config.md
+++ b/docs/code/interfaces/types_config.Config.md
@@ -27,7 +27,7 @@ Whether or not debug mode is enabled
 
 #### Defined in
 
-[src/types/config.ts:22](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L22)
+[src/types/config.ts:9](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L9)
 
 ___
 
@@ -39,7 +39,7 @@ Logger
 
 #### Defined in
 
-[src/types/config.ts:20](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L20)
+[src/types/config.ts:7](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L7)
 
 ___
 
@@ -51,7 +51,7 @@ The maximum depth to search for a specific file
 
 #### Defined in
 
-[src/types/config.ts:30](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L30)
+[src/types/config.ts:17](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L17)
 
 ___
 
@@ -63,7 +63,7 @@ The path to the project root directory
 
 #### Defined in
 
-[src/types/config.ts:24](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L24)
+[src/types/config.ts:11](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L11)
 
 ___
 
@@ -75,7 +75,7 @@ Indicates whether to trace all operations
 
 #### Defined in
 
-[src/types/config.ts:26](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L26)
+[src/types/config.ts:13](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L13)
 
 ___
 
@@ -87,4 +87,4 @@ The size of the trace buffer in megabytes
 
 #### Defined in
 
-[src/types/config.ts:28](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L28)
+[src/types/config.ts:15](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L15)

--- a/docs/code/interfaces/types_config.Config.md
+++ b/docs/code/interfaces/types_config.Config.md
@@ -27,7 +27,7 @@ Whether or not debug mode is enabled
 
 #### Defined in
 
-[src/types/config.ts:11](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L11)
+[src/types/config.ts:22](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L22)
 
 ___
 
@@ -39,7 +39,7 @@ Logger
 
 #### Defined in
 
-[src/types/config.ts:9](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L9)
+[src/types/config.ts:20](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L20)
 
 ___
 
@@ -51,7 +51,7 @@ The maximum depth to search for a specific file
 
 #### Defined in
 
-[src/types/config.ts:19](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L19)
+[src/types/config.ts:30](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L30)
 
 ___
 
@@ -63,7 +63,7 @@ The path to the project root directory
 
 #### Defined in
 
-[src/types/config.ts:13](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L13)
+[src/types/config.ts:24](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L24)
 
 ___
 
@@ -75,7 +75,7 @@ Indicates whether to trace all operations
 
 #### Defined in
 
-[src/types/config.ts:15](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L15)
+[src/types/config.ts:26](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L26)
 
 ___
 
@@ -87,4 +87,4 @@ The size of the trace buffer in megabytes
 
 #### Defined in
 
-[src/types/config.ts:17](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L17)
+[src/types/config.ts:28](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/config.ts#L28)

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,19 +1,6 @@
 import { isNode } from '../util'
 import { Logger, consoleLogger, nullLogger } from './logging'
 
-let fs: typeof import('fs')
-let path: typeof import('path')
-let url: typeof import('url')
-
-async function loadNodeModules() {
-  if (!isNode()) {
-    throw new Error('This module can only be used in Node.js environment.')
-  }
-  fs = await import('fs')
-  path = await import('path')
-  url = await import('url')
-}
-
 /** The AlgoKit configuration type */
 export interface Config {
   /** Logger */
@@ -105,7 +92,13 @@ export class UpdatableConfig implements Readonly<Config> {
    * This is only supported in a Node environment.
    */
   private async configureProjectRoot() {
-    await loadNodeModules()
+    if (!isNode()) {
+      throw new Error('`configureProjectRoot` can only be called in Node.js environment.')
+    }
+
+    const fs = await import('fs')
+    const path = await import('path')
+    const url = await import('url')
 
     // fileURLToPath and dirname is only available in Node, hence the check
     const { fileURLToPath } = url

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -100,15 +100,11 @@ export class UpdatableConfig implements Readonly<Config> {
     const path = await import('path')
     const url = await import('url')
 
-    // fileURLToPath and dirname is only available in Node, hence the check
-    const { fileURLToPath } = url
-    const { dirname } = path
-
     const _dirname =
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore: Unreachable code error
       // eslint-disable-next-line no-restricted-syntax
-      typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url))
+      typeof __dirname !== 'undefined' ? __dirname : path.dirname(url.fileURLToPath(import.meta.url))
 
     if (!_dirname) {
       return

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,3 +40,12 @@ export const calculateFundAmount = (
     return null
   }
 }
+
+/**
+ * Checks if the current environment is Node.js
+ *
+ * @returns A boolean indicating whether the current environment is Node.js
+ */
+export const isNode = () => {
+  return typeof process !== 'undefined' && process.versions != null && process.versions.node != null
+}


### PR DESCRIPTION
Fix proposal for https://github.com/algorandfoundation/algokit-utils-ts/issues/191

## Proposed Changes

- Adding lazy loading via dynamic import for all uses of node specific modules.
- Tested against algokit react template and a stock next js based project