### PR TITLE
chore: fixing dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,10 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'chore(deps)'
-    target-branch: 'main'
-groups:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    update-types: ['version-update:semver-minor', 'version-update:semver-patch']
+    groups:
+      all:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
# Proposed changes

- Hotfix to patch syntax in dependabot yaml to allow grouping by semver