### PR TITLE
feat: disable resource population by default

### DIFF
--- a/docs/code/interfaces/types_app.AppCallParams.md
+++ b/docs/code/interfaces/types_app.AppCallParams.md
@@ -161,7 +161,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Inherited from
 

--- a/docs/code/interfaces/types_app.AppDeploymentParams.md
+++ b/docs/code/interfaces/types_app.AppDeploymentParams.md
@@ -234,7 +234,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Inherited from
 

--- a/docs/code/interfaces/types_app.CreateAppParams.md
+++ b/docs/code/interfaces/types_app.CreateAppParams.md
@@ -195,7 +195,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Inherited from
 

--- a/docs/code/interfaces/types_app.UpdateAppParams.md
+++ b/docs/code/interfaces/types_app.UpdateAppParams.md
@@ -194,7 +194,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Inherited from
 

--- a/docs/code/interfaces/types_asset.AssetOptInParams.md
+++ b/docs/code/interfaces/types_asset.AssetOptInParams.md
@@ -150,7 +150,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Inherited from
 

--- a/docs/code/interfaces/types_asset.AssetOptOutParams.md
+++ b/docs/code/interfaces/types_asset.AssetOptOutParams.md
@@ -190,7 +190,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Inherited from
 

--- a/docs/code/interfaces/types_transaction.SendTransactionParams.md
+++ b/docs/code/interfaces/types_transaction.SendTransactionParams.md
@@ -89,7 +89,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Defined in
 

--- a/docs/code/interfaces/types_transfer.AlgoRekeyParams.md
+++ b/docs/code/interfaces/types_transfer.AlgoRekeyParams.md
@@ -136,7 +136,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Inherited from
 

--- a/docs/code/interfaces/types_transfer.AlgoTransferParams.md
+++ b/docs/code/interfaces/types_transfer.AlgoTransferParams.md
@@ -149,7 +149,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Inherited from
 

--- a/docs/code/interfaces/types_transfer.EnsureFundedParams.md
+++ b/docs/code/interfaces/types_transfer.EnsureFundedParams.md
@@ -174,7 +174,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Inherited from
 

--- a/docs/code/interfaces/types_transfer.TransferAssetParams.md
+++ b/docs/code/interfaces/types_transfer.TransferAssetParams.md
@@ -175,7 +175,7 @@ ___
 
 • `Optional` **populateAppCallResources**: `boolean`
 
-Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
 
 #### Inherited from
 

--- a/docs/code/modules/index.md
+++ b/docs/code/modules/index.md
@@ -349,7 +349,7 @@ the estimated rate.
 
 #### Defined in
 
-[src/transaction.ts:690](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L690)
+[src/transaction.ts:692](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L692)
 
 ___
 
@@ -405,7 +405,7 @@ Allows for control of fees on a `Transaction` or `SuggestedParams` object
 
 #### Defined in
 
-[src/transaction.ts:713](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L713)
+[src/transaction.ts:715](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L715)
 
 ___
 
@@ -1477,7 +1477,7 @@ The array of transactions with signers
 
 #### Defined in
 
-[src/transaction.ts:745](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L745)
+[src/transaction.ts:747](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L747)
 
 ___
 
@@ -1810,7 +1810,7 @@ The suggested transaction parameters
 
 #### Defined in
 
-[src/transaction.ts:736](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L736)
+[src/transaction.ts:738](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L738)
 
 ___
 
@@ -2145,7 +2145,7 @@ The dryrun result
 
 #### Defined in
 
-[src/transaction.ts:541](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L541)
+[src/transaction.ts:543](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L543)
 
 ___
 
@@ -2170,7 +2170,7 @@ The simulation result, which includes various details about how the transactions
 
 #### Defined in
 
-[src/transaction.ts:556](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L556)
+[src/transaction.ts:558](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L558)
 
 ___
 
@@ -2276,7 +2276,7 @@ A new ATC with the resources packed into the transactions
 
 #### Defined in
 
-[src/transaction.ts:285](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L285)
+[src/transaction.ts:287](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L287)
 
 ___
 
@@ -2436,7 +2436,7 @@ An object with transaction IDs, transactions, group transaction ID (`groupTransa
 
 #### Defined in
 
-[src/transaction.ts:416](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L416)
+[src/transaction.ts:418](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L418)
 
 ___
 
@@ -2461,7 +2461,7 @@ An object with transaction IDs, transactions, group transaction ID (`groupTransa
 
 #### Defined in
 
-[src/transaction.ts:588](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L588)
+[src/transaction.ts:590](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L590)
 
 ___
 
@@ -2740,4 +2740,4 @@ Throws an error if the transaction is not confirmed or rejected in the next `tim
 
 #### Defined in
 
-[src/transaction.ts:633](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L633)
+[src/transaction.ts:635](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L635)

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -208,7 +208,9 @@ export const sendTransaction = async function (
   let txnToSend = transaction
 
   // Populate  resources if the transaction is an appcall and populateAppCallResources wasn't explicitly set to false
-  if (txnToSend.type === algosdk.TransactionType.appl && sendParams?.populateAppCallResources !== false) {
+  // NOTE: Temporary false by default until this algod bug is fixed: https://github.com/algorand/go-algorand/issues/5914
+  //   if (txnToSend.type === algosdk.TransactionType.appl && sendParams?.populateAppCallResources !== false) {
+  if (txnToSend.type === algosdk.TransactionType.appl && sendParams?.populateAppCallResources === true) {
     const newAtc = new AtomicTransactionComposer()
     newAtc.addTransaction({ txn: txnToSend, signer: getSenderTransactionSigner(from) })
     const packed = await populateAppCallResources(newAtc, algod)

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -41,7 +41,7 @@ export interface SendTransactionParams {
   maxFee?: AlgoAmount
   /** The maximum number of rounds to wait for confirmation, only applies if `skipWaiting` is `undefined` or `false`, default: wait up to 5 rounds */
   maxRoundsToWaitForConfirmation?: number
-  /** Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.  */
+  /** **WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.  */
   populateAppCallResources?: boolean
 }
 


### PR DESCRIPTION
## Proposed Changes

Disables resource population by default due to https://github.com/algorand/go-algorand/issues/5914

This is technically a breaking change since it changes the default behavior of atc and appclient calls