### PR TITLE
fix: disable resource population in sendAtomicTransactionComposer

### DIFF
--- a/docs/code/modules/index.md
+++ b/docs/code/modules/index.md
@@ -349,7 +349,7 @@ the estimated rate.
 
 #### Defined in
 
-[src/transaction.ts:692](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L692)
+[src/transaction.ts:694](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L694)
 
 ___
 
@@ -405,7 +405,7 @@ Allows for control of fees on a `Transaction` or `SuggestedParams` object
 
 #### Defined in
 
-[src/transaction.ts:715](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L715)
+[src/transaction.ts:717](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L717)
 
 ___
 
@@ -1477,7 +1477,7 @@ The array of transactions with signers
 
 #### Defined in
 
-[src/transaction.ts:747](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L747)
+[src/transaction.ts:749](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L749)
 
 ___
 
@@ -1810,7 +1810,7 @@ The suggested transaction parameters
 
 #### Defined in
 
-[src/transaction.ts:738](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L738)
+[src/transaction.ts:740](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L740)
 
 ___
 
@@ -2145,7 +2145,7 @@ The dryrun result
 
 #### Defined in
 
-[src/transaction.ts:543](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L543)
+[src/transaction.ts:545](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L545)
 
 ___
 
@@ -2170,7 +2170,7 @@ The simulation result, which includes various details about how the transactions
 
 #### Defined in
 
-[src/transaction.ts:558](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L558)
+[src/transaction.ts:560](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L560)
 
 ___
 
@@ -2461,7 +2461,7 @@ An object with transaction IDs, transactions, group transaction ID (`groupTransa
 
 #### Defined in
 
-[src/transaction.ts:590](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L590)
+[src/transaction.ts:592](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L592)
 
 ___
 
@@ -2740,4 +2740,4 @@ Throws an error if the transaction is not confirmed or rejected in the next `tim
 
 #### Defined in
 
-[src/transaction.ts:635](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L635)
+[src/transaction.ts:637](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction.ts#L637)

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -420,16 +420,18 @@ export const sendAtomicTransactionComposer = async function (atcSend: AtomicTran
 
   let atc: AtomicTransactionComposer
 
-  const hasAppCalls = () =>
-    givenAtc
-      .buildGroup()
-      .map((t) => t.txn.type)
-      .includes(algosdk.TransactionType.appl)
+  // const hasAppCalls = () =>
+  //   givenAtc
+  //     .buildGroup()
+  //     .map((t) => t.txn.type)
+  //     .includes(algosdk.TransactionType.appl)
 
   atc = givenAtc
   try {
     // If populateAppCallResources is true OR if populateAppCallResources is undefined and there are app calls, then populate resources
-    if (sendParams?.populateAppCallResources || (sendParams?.populateAppCallResources === undefined && hasAppCalls())) {
+    // NOTE: Temporary false by default until this algod bug is fixed: https://github.com/algorand/go-algorand/issues/5914
+    // if (sendParams?.populateAppCallResources || (sendParams?.populateAppCallResources === undefined && hasAppCalls())) {
+    if (sendParams?.populateAppCallResources) {
       atc = await populateAppCallResources(givenAtc, algod)
     }
 

--- a/src/types/app-client.spec.ts
+++ b/src/types/app-client.spec.ts
@@ -676,7 +676,7 @@ describe('application-client', () => {
             .replace(/transaction [A-Z0-9]{52}/, 'transaction {TX_ID}')
             .trim(),
         ).toMatchInlineSnapshot(
-          `"Error: Error during resource population simulation in transaction 0: transaction {TX_ID}: logic eval error: assert failed pc=885. Details: pc=885, opcodes=proto 0 0; intc_0 // 0; assert"`,
+          `"URLTokenBaseHTTPError: Network request error. Received status 400 (Bad Request): TransactionPool.Remember: transaction {TX_ID}: logic eval error: assert failed pc=885. Details: pc=885, opcodes=proto 0 0; intc_0 // 0; assert"`,
         )
       }
 
@@ -723,7 +723,7 @@ describe('application-client', () => {
             .replace(/transaction [A-Z0-9]{52}/, 'transaction {TX_ID}')
             .trim(),
         ).toMatchInlineSnapshot(
-          `"Error: assert failed pc=885. at:469. Error during resource population simulation in transaction 0: transaction {TX_ID}: logic eval error: assert failed pc=885. Details: pc=885, opcodes=proto 0 0; intc_0 // 0; assert"`,
+          `"Error: assert failed pc=885. at:469. Network request error. Received status 400 (Bad Request): TransactionPool.Remember: transaction {TX_ID}: logic eval error: assert failed pc=885. Details: pc=885, opcodes=proto 0 0; intc_0 // 0; assert"`,
         )
         expect(e.stack).toMatchInlineSnapshot(`
           "// error


### PR DESCRIPTION
Disables resource population in `sendAtomicTransactionComposer`
