### PR TITLE
fix: update logic error parsing to handle the tweaked format from algod

### DIFF
--- a/docs/code/modules/index.md
+++ b/docs/code/modules/index.md
@@ -237,7 +237,7 @@ algokit.bulkOptOut({ account: account, assetIds: [12345, 67890] }, algod)
 
 #### Defined in
 
-[src/asset.ts:236](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L236)
+[src/asset.ts:237](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L237)
 
 ___
 

--- a/src/app-deploy.ts
+++ b/src/app-deploy.ts
@@ -593,8 +593,8 @@ export function performTemplateSubstitution(tealCode: string, templateParams?: T
         typeof value === 'string'
           ? `0x${Buffer.from(value, 'utf-8').toString('hex')}`
           : ArrayBuffer.isView(value)
-          ? `0x${Buffer.from(value).toString('hex')}`
-          : value.toString(),
+            ? `0x${Buffer.from(value).toString('hex')}`
+            : value.toString(),
       )
     }
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -600,12 +600,12 @@ export async function getAppArgsForABICall(args: ABIAppCallArgs, from: SendTrans
       return 'txn' in a
         ? a
         : a instanceof Promise
-        ? { txn: (await a).transaction, signer }
-        : 'transaction' in a
-        ? { txn: a.transaction, signer: 'signer' in a ? getSenderTransactionSigner(a.signer) : signer }
-        : 'txID' in a
-        ? { txn: a, signer }
-        : a
+          ? { txn: (await a).transaction, signer }
+          : 'transaction' in a
+            ? { txn: a.transaction, signer: 'signer' in a ? getSenderTransactionSigner(a.signer) : signer }
+            : 'txID' in a
+              ? { txn: a, signer }
+              : a
     }),
   )
   return {
@@ -641,8 +641,8 @@ export function getBoxReference(box: BoxIdentifier | BoxReference | algosdk.BoxR
       typeof ref.name === 'string'
         ? encoder.encode(ref.name)
         : 'length' in ref.name
-        ? ref.name
-        : algosdk.decodeAddress(getSenderAddress(ref.name)).publicKey,
+          ? ref.name
+          : algosdk.decodeAddress(getSenderAddress(ref.name)).publicKey,
   } as algosdk.BoxReference
 }
 

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -213,8 +213,9 @@ export async function assetBulkOptIn(optIn: AssetBulkOptInOutParams, algod: Algo
           `Successfully opted in ${getSenderAddress(account)} for asset ${assetId} with transaction ID ${
             sendGroupOfTransactionsResult.txIds[index]
           },
-          grouped under ${sendGroupOfTransactionsResult.groupId} round ${sendGroupOfTransactionsResult.confirmations?.[0]
-            ?.confirmedRound}.`,
+          grouped under ${sendGroupOfTransactionsResult.groupId} round ${
+            sendGroupOfTransactionsResult.confirmations?.[0]?.confirmedRound
+          }.`,
         )
       })
     } catch (e) {
@@ -282,8 +283,9 @@ export async function assetBulkOptOut(optOut: AssetBulkOptInOutParams, algod: Al
           `Successfully opted out ${getSenderAddress(account)} from asset ${asset.index} with transaction ID ${
             sendGroupOfTransactionsResult.txIds[index]
           },
-          grouped under ${sendGroupOfTransactionsResult.groupId} round ${sendGroupOfTransactionsResult.confirmations?.[0]
-            ?.confirmedRound}.`,
+          grouped under ${sendGroupOfTransactionsResult.groupId} round ${
+            sendGroupOfTransactionsResult.confirmations?.[0]?.confirmedRound
+          }.`,
         )
       })
     } catch (e) {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -133,14 +133,14 @@ export const getTransactionWithSigner = async (
         signer: getSenderTransactionSigner(defaultSender),
       }
     : 'transaction' in transaction
-    ? {
-        txn: transaction.transaction,
-        signer: getSenderTransactionSigner(transaction.signer),
-      }
-    : {
-        txn: transaction,
-        signer: getSenderTransactionSigner(defaultSender),
-      }
+      ? {
+          txn: transaction.transaction,
+          signer: getSenderTransactionSigner(transaction.signer),
+        }
+      : {
+          txn: transaction,
+          signer: getSenderTransactionSigner(defaultSender),
+        }
 }
 
 /**
@@ -153,8 +153,8 @@ export const getSenderTransactionSigner = memoize(function (sender: SendTransact
   return 'signer' in sender
     ? sender.signer
     : 'lsig' in sender
-    ? algosdk.makeLogicSigAccountTransactionSigner(sender)
-    : algosdk.makeBasicAccountTransactionSigner(sender)
+      ? algosdk.makeLogicSigAccountTransactionSigner(sender)
+      : algosdk.makeBasicAccountTransactionSigner(sender)
 })
 
 /**
@@ -167,10 +167,10 @@ export const signTransaction = async (transaction: Transaction, signer: SendTran
   return 'sk' in signer
     ? transaction.signTxn(signer.sk)
     : 'lsig' in signer
-    ? algosdk.signLogicSigTransactionObject(transaction, signer).blob
-    : 'sign' in signer
-    ? signer.sign(transaction)
-    : (await signer.signer([transaction], [0]))[0]
+      ? algosdk.signLogicSigTransactionObject(transaction, signer).blob
+      : 'sign' in signer
+        ? signer.sign(transaction)
+        : (await signer.signer([transaction], [0]))[0]
 }
 
 /** Prepares a transaction for sending and then (if instructed) signs and sends the given transaction to the chain.

--- a/src/types/__snapshots__/app-client.spec.ts.snap
+++ b/src/types/__snapshots__/app-client.spec.ts.snap
@@ -353,7 +353,7 @@ exports[`application-client Errors Display nice error messages when there is a l
     ]
   },
   "appBudget": 48,
-  "message": "transaction {TX_ID}: logic eval error: assert failed pc=885. Details: pc=885, opcodes=proto 0 0; intc_0 // 0; assert"
+  "message": "transaction {TX_ID}: logic eval error: assert failed pc=885. Details: app={APP_ID}, pc=885, opcodes=proto 0 0; intc_0 // 0; assert"
 }"
 `;
 

--- a/src/types/app-client.spec.ts
+++ b/src/types/app-client.spec.ts
@@ -676,7 +676,7 @@ describe('application-client', () => {
             .replace(/transaction [A-Z0-9]{52}/, 'transaction {TX_ID}')
             .trim(),
         ).toMatchInlineSnapshot(
-          `"URLTokenBaseHTTPError: Network request error. Received status 400 (Bad Request): TransactionPool.Remember: transaction {TX_ID}: logic eval error: assert failed pc=885. Details: pc=885, opcodes=proto 0 0; intc_0 // 0; assert"`,
+          `"URLTokenBaseHTTPError: Network request error. Received status 400 (Bad Request): TransactionPool.Remember: transaction {TX_ID}: logic eval error: assert failed pc=885. Details: app=${app.appId}, pc=885, opcodes=proto 0 0; intc_0 // 0; assert"`,
         )
       }
 
@@ -723,7 +723,7 @@ describe('application-client', () => {
             .replace(/transaction [A-Z0-9]{52}/, 'transaction {TX_ID}')
             .trim(),
         ).toMatchInlineSnapshot(
-          `"Error: assert failed pc=885. at:469. Network request error. Received status 400 (Bad Request): TransactionPool.Remember: transaction {TX_ID}: logic eval error: assert failed pc=885. Details: pc=885, opcodes=proto 0 0; intc_0 // 0; assert"`,
+          `"Error: assert failed pc=885. at:469. Network request error. Received status 400 (Bad Request): TransactionPool.Remember: transaction {TX_ID}: logic eval error: assert failed pc=885. Details: app=${app.appId}, pc=885, opcodes=proto 0 0; intc_0 // 0; assert"`,
         )
         expect(e.stack).toMatchInlineSnapshot(`
           "// error
@@ -738,7 +738,9 @@ describe('application-client', () => {
           create_8:"
         `)
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const originalData = JSON.stringify(e.led.traces[0], null, 2).replace(/transaction [A-Z0-9]{52}/, 'transaction {TX_ID}')
+        const originalData = JSON.stringify(e.led.traces[0], null, 2)
+          .replace(/transaction [A-Z0-9]{52}/, 'transaction {TX_ID}')
+          .replace(/app=[0-9]+/, 'app={APP_ID}')
         const updatedData = originalData.replace(/("pc": 345[\s\S]+?stack-additions[\s\S]+?uint": )\d+/g, '$1"APP_ID"')
         expect(updatedData).toMatchSnapshot()
       }

--- a/src/types/logic-error.ts
+++ b/src/types/logic-error.ts
@@ -1,6 +1,6 @@
 import type algosdk from 'algosdk'
 
-const LOGIC_ERROR = /transaction ([A-Z0-9]+): logic eval error: (.*). Details: pc=([0-9]+), opcodes=.*/
+const LOGIC_ERROR = /transaction ([A-Z0-9]+): logic eval error: (.*). Details: .*pc=([0-9]+).*/
 
 /**
  * Details about a smart contract logic error

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "declaration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["**/*.algo.ts"]
+  "exclude": ["**/*.algo.ts"],
 }


### PR DESCRIPTION
Fixes #223 

Unfortunately we can't use the new structured data payload, as it doesn't contain transactionId or the error message, so we need to parse the string anyway.