### PR TITLE
build: change exception id for npm audit

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,5 +1,5 @@
 {
-  "1096460": {
+  "1096519": {
     "active": true,
     "notes": "Ignored since the vulnerability is when hosting a server, but this is via semantic release which only uses it as a client",
     "expiry": 1711814399000


### PR DESCRIPTION
## Proposed Changes

- For some reason the ID for [CVE-2023-42282](https://github.com/advisories/GHSA-78xj-cgh5-2h22) changed with npm audit

