### PR TITLE
fix: double addr in resource population

### DIFF
--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -359,12 +359,18 @@ export async function populateAppCallResources(atc: algosdk.AtomicTransactionCom
       const txnIndex = findTxnBelowRefLimit(group, 'appLocal')
       group[txnIndex].txn.appForeignApps?.push(Number(a.app))
       group[txnIndex].txn.appAccounts?.push(algosdk.decodeAddress(a.account))
+
+      // Remove the account from the accounts list if we're adding it here
+      g.accounts = g.accounts?.filter((acc) => acc !== a.account)
     })
 
     g.assetHoldings?.forEach((a) => {
       const txnIndex = findTxnBelowRefLimit(group, 'assetHolding')
       group[txnIndex].txn.appForeignAssets?.push(Number(a.asset))
       group[txnIndex].txn.appAccounts?.push(algosdk.decodeAddress(a.account))
+
+      // Remove the account from the accounts list if we're adding it here
+      g.accounts = g.accounts?.filter((acc) => acc !== a.account)
     })
 
     // Do accounts next because the account limit is 4


### PR DESCRIPTION
## Proposed Changes

- Resource population would erroneously try to put the same address in the account array twice if that address was used for an assetHolding. This would result in a false error regarding not having enough space to populate resources
