### PR TITLE
Added `createAsset` and support 64-bit integers from indexer

### DIFF
--- a/docs/capabilities/asset.md
+++ b/docs/capabilities/asset.md
@@ -1,7 +1,42 @@
 # Assets
 
-The asset management functions include opting in and out of assets, which are fundamental to asset interaction in a blockchain environment.
+The Algorand Standard Asset (asset) management functions include creating, opting in and transferring assets, which are fundamental to asset interaction in a blockchain environment.
 To see some usage examples check out the [automated tests](../../src/asset.spec.ts).
+
+## Creation
+
+To create an asset you can use the `createAsset(create, algod)` function, which returns a [`SendTransactionResult`](./transaction.md#sendtransactionresult) and takes an [`AssetCreateParams`](../code/interfaces/types_asset.CreateAssetParams.md):
+
+- All properties in [`SendTransactionParams`](./transaction.md#sendtransactionparams)
+- `creator: SendTransactionFrom` - The account to create the asset. This account automatically is opted in to the asset and holds all units after creation.
+- `total: number | bigint` - The total number of base (decimal) units of the asset to create. If decimal is, say, 2, then for every 100 `total` there would be 1 whole unit.
+- `decimals: number` - The number of digits to use after the decimal point when displaying the asset. If 0, the asset is not divisible. If 1, the base unit of the asset is in tenths, and so on up to 19 decimal places.
+- `name?: string` - The optional name of the asset. Max size if 32 bytes.
+- `unit?: string` - The optional name of the unit of this asset. Max size is 8 bytes.
+- `url?: string` - Specifies an optional URL where more information about the asset can be retrieved. Max size is 96 bytes.
+- `metadataHash?: string | Uint8Array` - This field is intended to be a 32-byte hash of some metadata that is relevant to your asset and/or asset holders.
+- `manager?: string | SendTransactionFrom` - The optional account that can manage the configuration of the asset and destroy it.
+- `reserveAccount?: string | SendTransactionFrom` - The optional account that holds the reserve (non-minted) units of the asset. This address has no specific authority in the protocol itself and is informational.
+- `freezeAccount?: string | SendTransactionFrom` - The optional account that can be used to freeze holdings of this asset. If empty, freezing is not permitted.
+- `clawbackAccount?: string | SendTransactionFrom` - The optional account that can clawback holdings of this asset. If empty, clawback is not permitted.
+- `frozenByDefault?: boolean` - Whether to freeze holdings for this asset by default. If `true` then for anyone apart from the creator to hold the asset it needs to be unfrozen per account using `freeze`. Defaults to `false`.
+- `transactionParams?: SuggestedParams` - The optional [transaction parameters](./transaction.md#transaction-params)
+- `note?: TransactionNote` - The [transaction note](./transaction.md#transaction-notes)
+- `lease?: string | Uint8Array`: A [lease](https://developer.algorand.org/articles/leased-transactions-securing-advanced-smart-contract-design/) to assign to the transaction to enforce a mutually exclusive transaction (useful to prevent double-posting and other scenarios)
+
+```typescript
+await algokit.createAsset(
+  {
+    creator: account,
+    total: 100,
+    decimals: 0,
+    name: 'My asset',
+    // Can optionally specify other parameters per above
+    // Can optionally also specify transactionParams, note, lease and other send params
+  },
+  algod,
+)
+```
 
 ## Transfer
 
@@ -42,11 +77,14 @@ To opt-in an account to a single asset you can use the [`algokit.assetOptIn(optI
 
 ```typescript
 // Example
-await algokit.assetOptIn({
-  account: account,
-  assetId: 12345,
-  // Can optionally also specify transactionParams, note, lease and other send params
-})
+await algokit.assetOptIn(
+  {
+    account: account,
+    assetId: 12345,
+    // Can optionally also specify transactionParams, note, lease and other send params
+  },
+  algod,
+)
 ```
 
 ### `assetOptOut`
@@ -59,12 +97,15 @@ To opt-out an account from a single asset you can use the [`algokit.assetOptOut(
 
 ```typescript
 // Example
-await algokit.assetOptOut({
-  account: account,
-  assetId: 12345,
-  assetCreatorAddress: creator,
-  // Can optionally also specify ensureZeroBalance, transactionParams, note, lease and other send params
-})
+await algokit.assetOptOut(
+  {
+    account: account,
+    assetId: 12345,
+    assetCreatorAddress: creator,
+    // Can optionally also specify ensureZeroBalance, transactionParams, note, lease and other send params
+  },
+  algod,
+)
 ```
 
 ### `assetBulkOptIn`

--- a/docs/capabilities/client.md
+++ b/docs/capabilities/client.md
@@ -35,7 +35,7 @@ There are a number of ways to produce one of these configuration objects:
 Once you have the configuration for a client, to get the client you can use the following functions:
 
 - [`algokit.getAlgoClient(config)`](../code/modules/index.md#getalgoclient) - Returns an Algod client for the given configuration; the client automatically retries on transient HTTP errors; if one isn't provided it retrieves it from the environment
-- [`algokit.getAlgoIndexerClient(config)`](../code/modules/index.md#getalgoindexerclient) - Returns an Indexer client for given configuration; if one isn't provided it retrieves it from the environment
+- [`algokit.getAlgoIndexerClient(config, overrideIntDecoding)`](../code/modules/index.md#getalgoindexerclient) - Returns an Indexer client for given configuration; if one isn't provided it retrieves it from the environment
 - [`algokit.getAlgoKmdClient(config)`](../code/modules/index.md#getalgokmdclient) - Returns a Kmd client for the given configuration; if one isn't provided it retrieves it from the environment
 
 ## Automatic retry

--- a/docs/code/interfaces/types_asset.AssetBulkOptInOutParams.md
+++ b/docs/code/interfaces/types_asset.AssetBulkOptInOutParams.md
@@ -28,7 +28,7 @@ The account to opt in/out for
 
 #### Defined in
 
-[src/types/asset.ts:31](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L31)
+[src/types/asset.ts:94](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L94)
 
 ___
 
@@ -40,7 +40,7 @@ The IDs of the assets to opt in for / out of
 
 #### Defined in
 
-[src/types/asset.ts:33](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L33)
+[src/types/asset.ts:96](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L96)
 
 ___
 
@@ -52,7 +52,7 @@ The maximum fee that you are happy to pay per transaction (default: unbounded) -
 
 #### Defined in
 
-[src/types/asset.ts:41](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L41)
+[src/types/asset.ts:104](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L104)
 
 ___
 
@@ -64,7 +64,7 @@ The (optional) transaction note
 
 #### Defined in
 
-[src/types/asset.ts:39](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L39)
+[src/types/asset.ts:102](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L102)
 
 ___
 
@@ -76,7 +76,7 @@ Whether to suppress log messages from transaction send, default: do not suppress
 
 #### Defined in
 
-[src/types/asset.ts:43](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L43)
+[src/types/asset.ts:106](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L106)
 
 ___
 
@@ -88,7 +88,7 @@ Optional transaction parameters
 
 #### Defined in
 
-[src/types/asset.ts:37](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L37)
+[src/types/asset.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L100)
 
 ___
 
@@ -100,4 +100,4 @@ Whether or not to validate the opt-in/out is valid before issuing transactions; 
 
 #### Defined in
 
-[src/types/asset.ts:35](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L35)
+[src/types/asset.ts:98](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L98)

--- a/docs/code/interfaces/types_asset.AssetOptInParams.md
+++ b/docs/code/interfaces/types_asset.AssetOptInParams.md
@@ -42,7 +42,7 @@ The account to opt in/out for
 
 #### Defined in
 
-[src/types/asset.ts:9](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L9)
+[src/types/asset.ts:72](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L72)
 
 ___
 
@@ -54,7 +54,7 @@ The ID of the assets to opt in for / out of
 
 #### Defined in
 
-[src/types/asset.ts:11](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L11)
+[src/types/asset.ts:74](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L74)
 
 ___
 
@@ -98,7 +98,7 @@ An (optional) [transaction lease](https://developer.algorand.org/articles/leased
 
 #### Defined in
 
-[src/types/asset.ts:17](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L17)
+[src/types/asset.ts:80](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L80)
 
 ___
 
@@ -142,7 +142,7 @@ The (optional) transaction note
 
 #### Defined in
 
-[src/types/asset.ts:15](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L15)
+[src/types/asset.ts:78](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L78)
 
 ___
 
@@ -219,4 +219,4 @@ Optional transaction parameters
 
 #### Defined in
 
-[src/types/asset.ts:13](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L13)
+[src/types/asset.ts:76](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L76)

--- a/docs/code/interfaces/types_asset.AssetOptOutParams.md
+++ b/docs/code/interfaces/types_asset.AssetOptOutParams.md
@@ -46,7 +46,7 @@ The account to opt in/out for
 
 #### Defined in
 
-[src/types/asset.ts:9](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L9)
+[src/types/asset.ts:72](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L72)
 
 ___
 
@@ -58,7 +58,7 @@ The address of the creator account for the asset; if unspecified then it looks i
 
 #### Defined in
 
-[src/types/asset.ts:23](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L23)
+[src/types/asset.ts:86](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L86)
 
 ___
 
@@ -74,7 +74,7 @@ The ID of the assets to opt in for / out of
 
 #### Defined in
 
-[src/types/asset.ts:11](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L11)
+[src/types/asset.ts:74](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L74)
 
 ___
 
@@ -102,7 +102,7 @@ Whether or not to validate the account has a zero-balance before issuing the opt
 
 #### Defined in
 
-[src/types/asset.ts:25](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L25)
+[src/types/asset.ts:88](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L88)
 
 ___
 
@@ -134,7 +134,7 @@ An (optional) [transaction lease](https://developer.algorand.org/articles/leased
 
 #### Defined in
 
-[src/types/asset.ts:17](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L17)
+[src/types/asset.ts:80](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L80)
 
 ___
 
@@ -182,7 +182,7 @@ The (optional) transaction note
 
 #### Defined in
 
-[src/types/asset.ts:15](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L15)
+[src/types/asset.ts:78](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L78)
 
 ___
 
@@ -263,4 +263,4 @@ Optional transaction parameters
 
 #### Defined in
 
-[src/types/asset.ts:13](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L13)
+[src/types/asset.ts:76](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L76)

--- a/docs/code/interfaces/types_asset.CreateAssetParams.md
+++ b/docs/code/interfaces/types_asset.CreateAssetParams.md
@@ -1,0 +1,367 @@
+[@algorandfoundation/algokit-utils](../README.md) / [types/asset](../modules/types_asset.md) / CreateAssetParams
+
+# Interface: CreateAssetParams
+
+[types/asset](../modules/types_asset.md).CreateAssetParams
+
+Parameters for `createAsset` call.
+
+## Hierarchy
+
+- [`SendTransactionParams`](types_transaction.SendTransactionParams.md)
+
+  ↳ **`CreateAssetParams`**
+
+## Table of contents
+
+### Properties
+
+- [atc](types_asset.CreateAssetParams.md#atc)
+- [clawbackAccount](types_asset.CreateAssetParams.md#clawbackaccount)
+- [creator](types_asset.CreateAssetParams.md#creator)
+- [decimals](types_asset.CreateAssetParams.md#decimals)
+- [fee](types_asset.CreateAssetParams.md#fee)
+- [freezeAccount](types_asset.CreateAssetParams.md#freezeaccount)
+- [frozenByDefault](types_asset.CreateAssetParams.md#frozenbydefault)
+- [lease](types_asset.CreateAssetParams.md#lease)
+- [manager](types_asset.CreateAssetParams.md#manager)
+- [maxFee](types_asset.CreateAssetParams.md#maxfee)
+- [maxRoundsToWaitForConfirmation](types_asset.CreateAssetParams.md#maxroundstowaitforconfirmation)
+- [metadataHash](types_asset.CreateAssetParams.md#metadatahash)
+- [name](types_asset.CreateAssetParams.md#name)
+- [note](types_asset.CreateAssetParams.md#note)
+- [populateAppCallResources](types_asset.CreateAssetParams.md#populateappcallresources)
+- [reserveAccount](types_asset.CreateAssetParams.md#reserveaccount)
+- [skipSending](types_asset.CreateAssetParams.md#skipsending)
+- [skipWaiting](types_asset.CreateAssetParams.md#skipwaiting)
+- [suppressLog](types_asset.CreateAssetParams.md#suppresslog)
+- [total](types_asset.CreateAssetParams.md#total)
+- [transactionParams](types_asset.CreateAssetParams.md#transactionparams)
+- [unit](types_asset.CreateAssetParams.md#unit)
+- [url](types_asset.CreateAssetParams.md#url)
+
+## Properties
+
+### atc
+
+• `Optional` **atc**: `AtomicTransactionComposer`
+
+An optional `AtomicTransactionComposer` to add the transaction to, if specified then `skipSending: undefined` has the same effect as `skipSending: true`
+
+#### Inherited from
+
+[SendTransactionParams](types_transaction.SendTransactionParams.md).[atc](types_transaction.SendTransactionParams.md#atc)
+
+#### Defined in
+
+[src/types/transaction.ts:35](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/transaction.ts#L35)
+
+___
+
+### clawbackAccount
+
+• `Optional` **clawbackAccount**: `string` \| [`SendTransactionFrom`](../modules/types_transaction.md#sendtransactionfrom)
+
+The optional account that can clawback holdings of this asset. If empty, clawback is not permitted.
+If not set at asset creation or subsequently set to empty by the manager the field is permanently empty.
+
+#### Defined in
+
+[src/types/asset.ts:57](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L57)
+
+___
+
+### creator
+
+• **creator**: [`SendTransactionFrom`](../modules/types_transaction.md#sendtransactionfrom)
+
+The account to create the asset.
+
+This account automatically is opted in to the asset and holds all units after creation.
+
+#### Defined in
+
+[src/types/asset.ts:11](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L11)
+
+___
+
+### decimals
+
+• **decimals**: `number`
+
+The number of digits to use after the decimal point when displaying the asset.
+If 0, the asset is not divisible.
+If 1, the base unit of the asset is in tenths.
+If 2, the base unit of the asset is in hundredths.
+If 3, the base unit of the asset is in thousandths, and so on up to 19 decimal places.
+This field can only be specified upon asset creation.
+
+#### Defined in
+
+[src/types/asset.ts:26](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L26)
+
+___
+
+### fee
+
+• `Optional` **fee**: [`AlgoAmount`](../classes/types_amount.AlgoAmount.md)
+
+The flat fee you want to pay, useful for covering extra fees in a transaction group or app call
+
+#### Inherited from
+
+[SendTransactionParams](types_transaction.SendTransactionParams.md).[fee](types_transaction.SendTransactionParams.md#fee)
+
+#### Defined in
+
+[src/types/transaction.ts:39](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/transaction.ts#L39)
+
+___
+
+### freezeAccount
+
+• `Optional` **freezeAccount**: `string` \| [`SendTransactionFrom`](../modules/types_transaction.md#sendtransactionfrom)
+
+The optional account that can be used to freeze holdings of this asset. If empty, freezing is not permitted.
+If not set at asset creation or subsequently set to empty by the manager the field is permanently empty.
+
+#### Defined in
+
+[src/types/asset.ts:53](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L53)
+
+___
+
+### frozenByDefault
+
+• `Optional` **frozenByDefault**: `boolean`
+
+Whether to freeze holdings for this asset by default. If `true` then for anyone apart from the creator to hold the asset it needs to be unfrozen per account using `freeze`. Defaults to `false`.
+
+#### Defined in
+
+[src/types/asset.ts:59](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L59)
+
+___
+
+### lease
+
+• `Optional` **lease**: `string` \| `Uint8Array`
+
+An (optional) [transaction lease](https://developer.algorand.org/articles/leased-transactions-securing-advanced-smart-contract-design/) to apply
+
+#### Defined in
+
+[src/types/asset.ts:66](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L66)
+
+___
+
+### manager
+
+• `Optional` **manager**: `string` \| [`SendTransactionFrom`](../modules/types_transaction.md#sendtransactionfrom)
+
+The optional account that can manage the configuration of the asset and destroy it.
+If not set at asset creation or subsequently set to empty by the manager the asset becomes immutable.
+
+#### Defined in
+
+[src/types/asset.ts:43](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L43)
+
+___
+
+### maxFee
+
+• `Optional` **maxFee**: [`AlgoAmount`](../classes/types_amount.AlgoAmount.md)
+
+The maximum fee that you are happy to pay (default: unbounded) - if this is set it's possible the transaction could get rejected during network congestion
+
+#### Inherited from
+
+[SendTransactionParams](types_transaction.SendTransactionParams.md).[maxFee](types_transaction.SendTransactionParams.md#maxfee)
+
+#### Defined in
+
+[src/types/transaction.ts:41](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/transaction.ts#L41)
+
+___
+
+### maxRoundsToWaitForConfirmation
+
+• `Optional` **maxRoundsToWaitForConfirmation**: `number`
+
+The maximum number of rounds to wait for confirmation, only applies if `skipWaiting` is `undefined` or `false`, default: wait up to 5 rounds
+
+#### Inherited from
+
+[SendTransactionParams](types_transaction.SendTransactionParams.md).[maxRoundsToWaitForConfirmation](types_transaction.SendTransactionParams.md#maxroundstowaitforconfirmation)
+
+#### Defined in
+
+[src/types/transaction.ts:43](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/transaction.ts#L43)
+
+___
+
+### metadataHash
+
+• `Optional` **metadataHash**: `string` \| `Uint8Array`
+
+This field is intended to be a 32-byte hash of some metadata that is relevant to your asset and/or asset holders.
+The format of this metadata is up to the application. This field can only be specified upon asset creation.
+
+#### Defined in
+
+[src/types/asset.ts:39](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L39)
+
+___
+
+### name
+
+• `Optional` **name**: `string`
+
+The optional name of the asset. Max size if 32 bytes. This field can only be specified upon asset creation.
+
+#### Defined in
+
+[src/types/asset.ts:29](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L29)
+
+___
+
+### note
+
+• `Optional` **note**: [`TransactionNote`](../modules/types_transaction.md#transactionnote)
+
+The (optional) transaction note
+
+#### Defined in
+
+[src/types/asset.ts:64](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L64)
+
+___
+
+### populateAppCallResources
+
+• `Optional` **populateAppCallResources**: `boolean`
+
+**WARNING**: Not recommended for production use due to https://github.com/algorand/go-algorand/issues/5914. Whether to use simulate to automatically populate app call resources in the txn objects. Defaults to true when there are app calls in the group.
+
+#### Inherited from
+
+[SendTransactionParams](types_transaction.SendTransactionParams.md).[populateAppCallResources](types_transaction.SendTransactionParams.md#populateappcallresources)
+
+#### Defined in
+
+[src/types/transaction.ts:45](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/transaction.ts#L45)
+
+___
+
+### reserveAccount
+
+• `Optional` **reserveAccount**: `string` \| [`SendTransactionFrom`](../modules/types_transaction.md#sendtransactionfrom)
+
+The optional account that holds the reserve (non-minted) units of the asset. This address has no specific authority in the protocol itself and is informational.
+Some standards like [ARC-19](https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0019.md) rely on this field to hold meaningful data.
+It is used in the case where you want to signal to holders of your asset that the non-minted units of the asset reside in an account that is different from the default creator account.
+If not set at asset creation or subsequently set to empty by the manager the field is permanently empty.
+
+#### Defined in
+
+[src/types/asset.ts:49](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L49)
+
+___
+
+### skipSending
+
+• `Optional` **skipSending**: `boolean`
+
+Whether to skip signing and sending the transaction to the chain (default: transaction signed and sent to chain, unless `atc` specified)
+and instead just return the raw transaction, e.g. so you can add it to a group of transactions
+
+#### Inherited from
+
+[SendTransactionParams](types_transaction.SendTransactionParams.md).[skipSending](types_transaction.SendTransactionParams.md#skipsending)
+
+#### Defined in
+
+[src/types/transaction.ts:31](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/transaction.ts#L31)
+
+___
+
+### skipWaiting
+
+• `Optional` **skipWaiting**: `boolean`
+
+Whether to skip waiting for the submitted transaction (only relevant if `skipSending` is `false` or unset)
+
+#### Inherited from
+
+[SendTransactionParams](types_transaction.SendTransactionParams.md).[skipWaiting](types_transaction.SendTransactionParams.md#skipwaiting)
+
+#### Defined in
+
+[src/types/transaction.ts:33](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/transaction.ts#L33)
+
+___
+
+### suppressLog
+
+• `Optional` **suppressLog**: `boolean`
+
+Whether to suppress log messages from transaction send, default: do not suppress
+
+#### Inherited from
+
+[SendTransactionParams](types_transaction.SendTransactionParams.md).[suppressLog](types_transaction.SendTransactionParams.md#suppresslog)
+
+#### Defined in
+
+[src/types/transaction.ts:37](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/transaction.ts#L37)
+
+___
+
+### total
+
+• **total**: `number` \| `bigint`
+
+The total number of base (decimal) units of the asset to create.
+If decimal is, say, 2, then for every 100 `total` there would be 1 whole unit.
+This field can only be specified upon asset creation.
+
+#### Defined in
+
+[src/types/asset.ts:17](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L17)
+
+___
+
+### transactionParams
+
+• `Optional` **transactionParams**: `SuggestedParams`
+
+Optional transaction parameters
+
+#### Defined in
+
+[src/types/asset.ts:62](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L62)
+
+___
+
+### unit
+
+• `Optional` **unit**: `string`
+
+The optional name of the unit of this asset. Max size is 8 bytes. This field can only be specified upon asset creation.
+
+#### Defined in
+
+[src/types/asset.ts:31](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L31)
+
+___
+
+### url
+
+• `Optional` **url**: `string`
+
+Specifies an optional URL where more information about the asset can be retrieved. Max size is 96 bytes.
+This field can only be specified upon asset creation.
+
+#### Defined in
+
+[src/types/asset.ts:35](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset.ts#L35)

--- a/docs/code/interfaces/types_indexer.AssetHolding.md
+++ b/docs/code/interfaces/types_indexer.AssetHolding.md
@@ -21,7 +21,7 @@ Describes an asset held by an account. https://developer.algorand.org/docs/rest-
 
 ### amount
 
-• **amount**: `number`
+• **amount**: `number` \| `bigint`
 
 (a) number of units held.
 

--- a/docs/code/interfaces/types_indexer.AssetTransferTransactionResult.md
+++ b/docs/code/interfaces/types_indexer.AssetTransferTransactionResult.md
@@ -21,7 +21,7 @@ Fields for an asset transfer transaction. https://developer.algorand.org/docs/re
 
 ### amount
 
-• **amount**: `number`
+• **amount**: `number` \| `bigint`
 
 [aamt] Amount of asset to transfer. A zero amount transferred to self allocates that asset in the account's Assets map.
 
@@ -45,7 +45,7 @@ ___
 
 ### close-amount
 
-• `Optional` **close-amount**: `number`
+• `Optional` **close-amount**: `number` \| `bigint`
 
 Number of assets transfered to the close-to account as part of the transaction.
 

--- a/docs/code/interfaces/types_indexer.StateProofTransactionResult.md
+++ b/docs/code/interfaces/types_indexer.StateProofTransactionResult.md
@@ -42,7 +42,7 @@ are needed in order to verify the next state proofs (VotersCommitment and LnProv
 | `block-headers-commitment` | `string` | [b] BlockHeadersCommitment contains a commitment on all light block headers within a state proof interval. |
 | `first-attested-round` | `number` | [f] First round the message attests to |
 | `latest-attested-round` | `number` | [l] Last round the message attests to |
-| `ln-proven-weight` | `number` | [P] An integer value representing the natural log of the proven weight with 16 bits of precision. This value would be used to verify the next state proof. |
+| `ln-proven-weight` | `number` \| `bigint` | [P] An integer value representing the natural log of the proven weight with 16 bits of precision. This value would be used to verify the next state proof. |
 | `voters-commitment` | `string` | [v] The vector commitment root of the top N accounts to sign the next StateProof. Pattern : "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\\|[A-Za-z0-9+/]{3}=)?$" |
 
 #### Defined in
@@ -63,11 +63,11 @@ ___
 | :------ | :------ | :------ |
 | `part-proofs` | [`MerkleArrayProof`](types_indexer.MerkleArrayProof.md) | [P] Part proofs that make up the overall proof |
 | `positions-to-reveal` | `number`[] | [pr] The positions that are revealed |
-| `reveals` | \{ `participant`: \{ `verifier`: \{ `commitment`: `string` ; `key-lifetime`: `number`  } ; `weight`: `number`  } ; `position`: `number` ; `sig-slot`: \{ `lower-sig-weight`: `number` ; `signature`: \{ `falcon-signature`: `string` ; `merkle-array-index`: `number` ; `proof`: [`MerkleArrayProof`](types_indexer.MerkleArrayProof.md) ; `verifying-key`: `string`  }  }  }[] | [r] Reveals is a sparse map from the position being revealed to the corresponding elements from the sigs and participants arrays. |
+| `reveals` | \{ `participant`: \{ `verifier`: \{ `commitment`: `string` ; `key-lifetime`: `number`  } ; `weight`: `number` \| `bigint`  } ; `position`: `number` ; `sig-slot`: \{ `lower-sig-weight`: `number` \| `bigint` ; `signature`: \{ `falcon-signature`: `string` ; `merkle-array-index`: `number` ; `proof`: [`MerkleArrayProof`](types_indexer.MerkleArrayProof.md) ; `verifying-key`: `string`  }  }  }[] | [r] Reveals is a sparse map from the position being revealed to the corresponding elements from the sigs and participants arrays. |
 | `salt-version` | `number` | [v] Merkle signature salt version |
 | `sig-commit` | `string` | [c] Digest of the signature commit |
 | `sig-proofs` | [`MerkleArrayProof`](types_indexer.MerkleArrayProof.md) | [S] Proofs for the signature |
-| `signed-weight` | `number` | [w] The combined weight of the signatures |
+| `signed-weight` | `number` \| `bigint` | [w] The combined weight of the signatures |
 
 #### Defined in
 

--- a/docs/code/interfaces/types_transaction.SendTransactionParams.md
+++ b/docs/code/interfaces/types_transaction.SendTransactionParams.md
@@ -12,6 +12,8 @@ The sending configuration for a transaction
 
   ↳ [`AppCallParams`](types_app.AppCallParams.md)
 
+  ↳ [`CreateAssetParams`](types_asset.CreateAssetParams.md)
+
   ↳ [`AssetOptInParams`](types_asset.AssetOptInParams.md)
 
   ↳ [`AlgoTransferParams`](types_transfer.AlgoTransferParams.md)

--- a/docs/code/modules/index.md
+++ b/docs/code/modules/index.md
@@ -23,6 +23,7 @@
 - [compileTeal](index.md#compileteal)
 - [controlFees](index.md#controlfees)
 - [createApp](index.md#createapp)
+- [createAsset](index.md#createasset)
 - [decodeAppState](index.md#decodeappstate)
 - [deployApp](index.md#deployapp)
 - [encodeLease](index.md#encodelease)
@@ -202,7 +203,7 @@ algokit.bulkOptIn({ account: account, assetIds: [12345, 67890] }, algod)
 
 #### Defined in
 
-[src/asset.ts:170](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L170)
+[src/asset.ts:237](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L237)
 
 ___
 
@@ -237,7 +238,7 @@ algokit.bulkOptOut({ account: account, assetIds: [12345, 67890] }, algod)
 
 #### Defined in
 
-[src/asset.ts:237](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L237)
+[src/asset.ts:304](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L304)
 
 ___
 
@@ -268,7 +269,7 @@ await algokit.assetOptIn({ account, assetId }, algod)
 
 #### Defined in
 
-[src/asset.ts:81](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L81)
+[src/asset.ts:148](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L148)
 
 ___
 
@@ -299,7 +300,7 @@ await algokit.assetOptOut({ account, assetId, assetCreatorAddress }, algod)
 
 #### Defined in
 
-[src/asset.ts:119](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L119)
+[src/asset.ts:186](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L186)
 
 ___
 
@@ -431,6 +432,37 @@ The details of the created app, or the transaction to create it if `skipSending`
 #### Defined in
 
 [src/app.ts:56](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app.ts#L56)
+
+___
+
+### createAsset
+
+▸ **createAsset**(`create`, `algod`): `Promise`\<[`SendTransactionResult`](../interfaces/types_transaction.SendTransactionResult.md)\>
+
+Create an Algorand Standard Asset (ASA).
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `create` | [`CreateAssetParams`](../interfaces/types_asset.CreateAssetParams.md) | The asset creation definition |
+| `algod` | `default` | An algod client |
+
+#### Returns
+
+`Promise`\<[`SendTransactionResult`](../interfaces/types_transaction.SendTransactionResult.md)\>
+
+The transaction object and optionally the confirmation if it was sent to the chain (`skipSending` is `false` or unset)
+
+**`Example`**
+
+```typescript
+await algokit.createAsset({ creator: account, total: 1, decimals: 0, name: 'My asset' }, algod)
+```
+
+#### Defined in
+
+[src/asset.ts:81](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L81)
 
 ___
 
@@ -623,7 +655,7 @@ ___
 
 #### Defined in
 
-[src/indexer-lookup.ts:109](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L109)
+[src/indexer-lookup.ts:133](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L133)
 
 ___
 
@@ -1950,7 +1982,7 @@ The result of the look-up
 
 #### Defined in
 
-[src/indexer-lookup.ts:30](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L30)
+[src/indexer-lookup.ts:54](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L54)
 
 ___
 
@@ -1977,7 +2009,7 @@ The list of application results
 
 #### Defined in
 
-[src/indexer-lookup.ts:42](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L42)
+[src/indexer-lookup.ts:66](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L66)
 
 ___
 
@@ -2002,7 +2034,7 @@ The result of the look-up
 
 #### Defined in
 
-[src/indexer-lookup.ts:20](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L20)
+[src/indexer-lookup.ts:42](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L42)
 
 ___
 
@@ -2411,7 +2443,7 @@ The search results
 
 #### Defined in
 
-[src/indexer-lookup.ts:75](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L75)
+[src/indexer-lookup.ts:99](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L99)
 
 ___
 

--- a/docs/code/modules/index.md
+++ b/docs/code/modules/index.md
@@ -203,7 +203,7 @@ algokit.bulkOptIn({ account: account, assetIds: [12345, 67890] }, algod)
 
 #### Defined in
 
-[src/asset.ts:237](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L237)
+[src/asset.ts:241](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L241)
 
 ___
 
@@ -238,7 +238,7 @@ algokit.bulkOptOut({ account: account, assetIds: [12345, 67890] }, algod)
 
 #### Defined in
 
-[src/asset.ts:304](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L304)
+[src/asset.ts:308](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L308)
 
 ___
 
@@ -269,7 +269,7 @@ await algokit.assetOptIn({ account, assetId }, algod)
 
 #### Defined in
 
-[src/asset.ts:148](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L148)
+[src/asset.ts:152](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L152)
 
 ___
 
@@ -300,7 +300,7 @@ await algokit.assetOptOut({ account, assetId, assetCreatorAddress }, algod)
 
 #### Defined in
 
-[src/asset.ts:186](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L186)
+[src/asset.ts:190](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/asset.ts#L190)
 
 ___
 
@@ -437,7 +437,7 @@ ___
 
 ### createAsset
 
-▸ **createAsset**(`create`, `algod`): `Promise`\<[`SendTransactionResult`](../interfaces/types_transaction.SendTransactionResult.md)\>
+▸ **createAsset**(`create`, `algod`): `Promise`\<[`SendTransactionResult`](../interfaces/types_transaction.SendTransactionResult.md) & \{ `confirmation?`: \{ `assetIndex`: `number` \| `bigint`  }  }\>
 
 Create an Algorand Standard Asset (ASA).
 
@@ -450,7 +450,7 @@ Create an Algorand Standard Asset (ASA).
 
 #### Returns
 
-`Promise`\<[`SendTransactionResult`](../interfaces/types_transaction.SendTransactionResult.md)\>
+`Promise`\<[`SendTransactionResult`](../interfaces/types_transaction.SendTransactionResult.md) & \{ `confirmation?`: \{ `assetIndex`: `number` \| `bigint`  }  }\>
 
 The transaction object and optionally the confirmation if it was sent to the chain (`skipSending` is `false` or unset)
 
@@ -655,7 +655,7 @@ ___
 
 #### Defined in
 
-[src/indexer-lookup.ts:133](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L133)
+[src/indexer-lookup.ts:109](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L109)
 
 ___
 
@@ -920,13 +920,13 @@ Returns an algod SDK client that automatically retries on idempotent calls
 
 #### Defined in
 
-[src/network-client.ts:129](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L129)
+[src/network-client.ts:130](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L130)
 
 ___
 
 ### getAlgoIndexerClient
 
-▸ **getAlgoIndexerClient**(`config?`): `Indexer`
+▸ **getAlgoIndexerClient**(`config?`, `overrideIntDecoding?`): `Indexer`
 
 Returns an indexer SDK client that automatically retries on idempotent calls
 
@@ -935,6 +935,7 @@ Returns an indexer SDK client that automatically retries on idempotent calls
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `config?` | [`AlgoClientConfig`](../interfaces/types_network_client.AlgoClientConfig.md) | The config if you want to override the default (getting config from process.env) |
+| `overrideIntDecoding?` | `IntDecoding` | Override the default int decoding for responses, uses MIXED by default to avoid lost precision for big integers |
 
 #### Returns
 
@@ -944,7 +945,6 @@ Returns an indexer SDK client that automatically retries on idempotent calls
 
 ```typescript
  // Uses process.env.INDEXER_SERVER, process.env.INDEXER_PORT and process.env.INDEXER_TOKEN
- // Automatically detects if you are using PureStake to switch in the right header name for INDEXER_TOKEN
  const indexer = getAlgoIndexerClient()
  await indexer.makeHealthCheck().do()
  ```
@@ -970,9 +970,15 @@ Returns an indexer SDK client that automatically retries on idempotent calls
  await indexer.makeHealthCheck().do()
 ```
 
+**`Example`**
+
+```typescript
+ const indexer = getAlgoIndexerClient(config, IntDecoding.BIGINT)
+```
+
 #### Defined in
 
-[src/network-client.ts:162](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L162)
+[src/network-client.ts:167](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L167)
 
 ___
 
@@ -1009,7 +1015,7 @@ KMD client allows you to export private keys, which is useful to get the default
 
 #### Defined in
 
-[src/network-client.ts:185](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L185)
+[src/network-client.ts:193](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L193)
 
 ___
 
@@ -1032,7 +1038,7 @@ Returns the Algorand configuration to point to the AlgoNode service
 
 #### Defined in
 
-[src/network-client.ts:75](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L75)
+[src/network-client.ts:76](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L76)
 
 ___
 
@@ -1048,7 +1054,7 @@ Retrieve the algod configuration from environment variables (expects to be calle
 
 #### Defined in
 
-[src/network-client.ts:37](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L37)
+[src/network-client.ts:38](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L38)
 
 ___
 
@@ -1549,7 +1555,7 @@ Retrieve configurations from environment variables when defined or get defaults 
 
 #### Defined in
 
-[src/network-client.ts:10](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L10)
+[src/network-client.ts:11](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L11)
 
 ___
 
@@ -1598,7 +1604,7 @@ Returns the Algorand configuration to point to the default LocalNet
 
 #### Defined in
 
-[src/network-client.ts:86](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L86)
+[src/network-client.ts:87](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L87)
 
 ___
 
@@ -1640,7 +1646,7 @@ Retrieve the indexer configuration from environment variables (expects to be cal
 
 #### Defined in
 
-[src/network-client.ts:54](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L54)
+[src/network-client.ts:55](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L55)
 
 ___
 
@@ -1910,7 +1916,7 @@ ___
 
 #### Defined in
 
-[src/network-client.ts:197](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L197)
+[src/network-client.ts:205](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L205)
 
 ___
 
@@ -1957,7 +1963,7 @@ ___
 
 #### Defined in
 
-[src/network-client.ts:192](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L192)
+[src/network-client.ts:200](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/network-client.ts#L200)
 
 ___
 
@@ -1982,7 +1988,7 @@ The result of the look-up
 
 #### Defined in
 
-[src/indexer-lookup.ts:54](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L54)
+[src/indexer-lookup.ts:30](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L30)
 
 ___
 
@@ -2009,7 +2015,7 @@ The list of application results
 
 #### Defined in
 
-[src/indexer-lookup.ts:66](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L66)
+[src/indexer-lookup.ts:42](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L42)
 
 ___
 
@@ -2034,7 +2040,7 @@ The result of the look-up
 
 #### Defined in
 
-[src/indexer-lookup.ts:42](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L42)
+[src/indexer-lookup.ts:20](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L20)
 
 ___
 
@@ -2443,7 +2449,7 @@ The search results
 
 #### Defined in
 
-[src/indexer-lookup.ts:99](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L99)
+[src/indexer-lookup.ts:75](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/indexer-lookup.ts#L75)
 
 ___
 

--- a/docs/code/modules/types_asset.md
+++ b/docs/code/modules/types_asset.md
@@ -9,3 +9,4 @@
 - [AssetBulkOptInOutParams](../interfaces/types_asset.AssetBulkOptInOutParams.md)
 - [AssetOptInParams](../interfaces/types_asset.AssetOptInParams.md)
 - [AssetOptOutParams](../interfaces/types_asset.AssetOptOutParams.md)
+- [CreateAssetParams](../interfaces/types_asset.CreateAssetParams.md)

--- a/src/indexer-lookup.spec.ts
+++ b/src/indexer-lookup.spec.ts
@@ -85,4 +85,71 @@ describe('indexer-lookup', () => {
 
     expect(apps.map((a) => a.id).sort()).toEqual([app1.appId, app2.appId].sort())
   })
+
+  test('Asset transfer and creation transactions are found by search or by ID with amounts gt 53-bit', async () => {
+    const { algod, indexer, testAccount, generateAccount, waitForIndexer } = localnet.context
+    const secondAccount = await generateAccount({
+      initialFunds: algokit.algos(1),
+      suppressLog: true,
+    })
+    const asset = await algokit.createAsset(
+      {
+        creator: testAccount,
+        total: 135_640_597_783_270_615n,
+        decimals: 0,
+      },
+      algod,
+    )
+    await algokit.assetOptIn(
+      {
+        account: secondAccount,
+        assetId: Number(asset.confirmation!.assetIndex),
+      },
+      algod,
+    )
+    const transfer = await algokit.transferAsset(
+      {
+        amount: 134_640_597_783_270_615n,
+        from: testAccount,
+        to: secondAccount,
+        assetId: Number(asset.confirmation!.assetIndex),
+      },
+      algod,
+    )
+    const closeOut = await algokit.sendTransaction(
+      {
+        transaction: algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject({
+          assetIndex: Number(asset.confirmation!.assetIndex),
+          from: algokit.getSenderAddress(secondAccount),
+          to: algokit.getSenderAddress(testAccount),
+          closeRemainderTo: algokit.getSenderAddress(testAccount),
+          amount: 257,
+          suggestedParams: await algokit.getTransactionParams(undefined, algod),
+        }),
+        from: secondAccount,
+      },
+      algod,
+    )
+    await waitForIndexer()
+
+    const searchTransactions = (await algokit.searchTransactions(indexer, (s) => s.assetID(Number(asset.confirmation!.assetIndex))))
+      .transactions
+
+    const acfgTxn = await algokit.lookupTransactionById(asset.transaction.txID(), indexer)
+    const acfgTxnFromSearch = searchTransactions.find((t) => t.id === asset.transaction.txID())!
+    expect(acfgTxn.transaction['asset-config-transaction']!.params!.total).toBe(135_640_597_783_270_615n)
+    expect(acfgTxnFromSearch['asset-config-transaction']!.params!.total).toBe(135_640_597_783_270_615n)
+
+    const axferTxn = await algokit.lookupTransactionById(transfer.transaction.txID(), indexer)
+    const axferTxnFromSearch = searchTransactions.find((t) => t.id === transfer.transaction.txID())!
+    expect(axferTxn.transaction['asset-transfer-transaction']!.amount).toBe(134_640_597_783_270_615n)
+    expect(axferTxnFromSearch['asset-transfer-transaction']!.amount).toBe(134_640_597_783_270_615n)
+
+    const closeOutTxn = await algokit.lookupTransactionById(closeOut.transaction.txID(), indexer)
+    const closeOutTxnFromSearch = searchTransactions.find((t) => t.id === closeOut.transaction.txID())!
+    expect(closeOutTxn.transaction['asset-transfer-transaction']!.amount).toBe(257)
+    expect(closeOutTxnFromSearch['asset-transfer-transaction']!.amount).toBe(257)
+    expect(closeOutTxn.transaction['asset-transfer-transaction']!['close-amount']).toBe(134_640_597_783_270_615n - 257n)
+    expect(closeOutTxnFromSearch['asset-transfer-transaction']!['close-amount']).toBe(134_640_597_783_270_615n - 257n)
+  })
 })

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -3,6 +3,69 @@ import { AlgoAmount } from './amount'
 import { SendTransactionFrom, SendTransactionParams, TransactionNote } from './transaction'
 import SuggestedParams = algosdk.SuggestedParams
 
+/** Parameters for `createAsset` call. */
+export interface CreateAssetParams extends SendTransactionParams {
+  /** The account to create the asset.
+   *
+   * This account automatically is opted in to the asset and holds all units after creation. */
+  creator: SendTransactionFrom
+
+  /** The total number of base (decimal) units of the asset to create.
+   * If decimal is, say, 2, then for every 100 `total` there would be 1 whole unit.
+   * This field can only be specified upon asset creation.
+   */
+  total: number | bigint
+
+  /** The number of digits to use after the decimal point when displaying the asset.
+   * If 0, the asset is not divisible.
+   * If 1, the base unit of the asset is in tenths.
+   * If 2, the base unit of the asset is in hundredths.
+   * If 3, the base unit of the asset is in thousandths, and so on up to 19 decimal places.
+   * This field can only be specified upon asset creation.
+   */
+  decimals: number
+
+  /** The optional name of the asset. Max size if 32 bytes. This field can only be specified upon asset creation. */
+  name?: string
+  /** The optional name of the unit of this asset. Max size is 8 bytes. This field can only be specified upon asset creation. */
+  unit?: string
+  /** Specifies an optional URL where more information about the asset can be retrieved. Max size is 96 bytes.
+   * This field can only be specified upon asset creation.
+   */
+  url?: string
+  /** This field is intended to be a 32-byte hash of some metadata that is relevant to your asset and/or asset holders.
+   * The format of this metadata is up to the application. This field can only be specified upon asset creation.
+   */
+  metadataHash?: string | Uint8Array
+  /** The optional account that can manage the configuration of the asset and destroy it.
+   * If not set at asset creation or subsequently set to empty by the manager the asset becomes immutable.
+   */
+  manager?: string | SendTransactionFrom
+  /** The optional account that holds the reserve (non-minted) units of the asset. This address has no specific authority in the protocol itself and is informational.
+   * Some standards like [ARC-19](https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0019.md) rely on this field to hold meaningful data.
+   * It is used in the case where you want to signal to holders of your asset that the non-minted units of the asset reside in an account that is different from the default creator account.
+   * If not set at asset creation or subsequently set to empty by the manager the field is permanently empty.
+   */
+  reserveAccount?: string | SendTransactionFrom
+  /** The optional account that can be used to freeze holdings of this asset. If empty, freezing is not permitted.
+   * If not set at asset creation or subsequently set to empty by the manager the field is permanently empty.
+   */
+  freezeAccount?: string | SendTransactionFrom
+  /** The optional account that can clawback holdings of this asset. If empty, clawback is not permitted.
+   * If not set at asset creation or subsequently set to empty by the manager the field is permanently empty.
+   */
+  clawbackAccount?: string | SendTransactionFrom
+  /** Whether to freeze holdings for this asset by default. If `true` then for anyone apart from the creator to hold the asset it needs to be unfrozen per account using `freeze`. Defaults to `false`. */
+  frozenByDefault?: boolean
+
+  /** Optional transaction parameters */
+  transactionParams?: SuggestedParams
+  /** The (optional) transaction note */
+  note?: TransactionNote
+  /** An (optional) [transaction lease](https://developer.algorand.org/articles/leased-transactions-securing-advanced-smart-contract-design/) to apply */
+  lease?: string | Uint8Array
+}
+
 /** Parameters for `assetOptIn` call. */
 export interface AssetOptInParams extends SendTransactionParams {
   /** The account to opt in/out for */

--- a/src/types/indexer.ts
+++ b/src/types/indexer.ts
@@ -300,7 +300,7 @@ export interface StateProofTransactionResult {
     /** [l] Last round the message attests to */
     'latest-attested-round': number
     /** [P] An integer value representing the natural log of the proven weight with 16 bits of precision. This value would be used to verify the next state proof. */
-    'ln-proven-weight': number
+    'ln-proven-weight': number | bigint
     /** [v] The vector commitment root of the top N accounts to sign the next StateProof.
      *
      * Pattern : "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$" */
@@ -343,7 +343,7 @@ export interface StateProofTransactionResult {
           'key-lifetime': number
         }
         /** [w] Weight is AccountData.MicroAlgos. */
-        weight: number
+        weight: number | bigint
       }
       /** [s] A sigslotCommit is a single slot in the sigs array that forms the state proof. */
       'sig-slot': {
@@ -351,7 +351,7 @@ export interface StateProofTransactionResult {
          * This is initialized once the builder has collected a sufficient
          * number of signatures.
          */
-        'lower-sig-weight': number
+        'lower-sig-weight': number | bigint
         /** [s] Sig is a signature by the participant on the expected message.
          *
          * Signature represents a signature in the Merkle signature scheme using falcon signatures as an underlying crypto scheme.
@@ -380,7 +380,7 @@ export interface StateProofTransactionResult {
     /** [S] Proofs for the signature */
     'sig-proofs': MerkleArrayProof
     /** [w] The combined weight of the signatures */
-    'signed-weight': number
+    'signed-weight': number | bigint
   }
   /** [sptype] State proof type, per https://github.com/algorand/go-algorand/blob/master/protocol/stateproof.go#L24
    *
@@ -484,11 +484,11 @@ export interface AssetFreezeTransactionResult {
 /** Fields for an asset transfer transaction. https://developer.algorand.org/docs/rest-apis/indexer/#transactionassettransfer */
 export interface AssetTransferTransactionResult {
   /** [aamt] Amount of asset to transfer. A zero amount transferred to self allocates that asset in the account's Assets map. */
-  amount: number
+  amount: number | bigint
   /** [xaid] ID of the asset being transferred. */
   'asset-id': number
   /** Number of assets transfered to the close-to account as part of the transaction. */
-  'close-amount'?: number
+  'close-amount'?: number | bigint
   /** [aclose] Indicates that the asset should be removed from the account's Assets map, and specifies where the remaining asset holdings should be transferred. It's always valid to transfer remaining asset holdings to the creator account. */
   'close-to'?: string
   /** [arcv] Recipient address of the transfer. */
@@ -820,7 +820,7 @@ export interface AssetHolding {
   /**
    * (a) number of units held.
    */
-  amount: number
+  amount: number | bigint
   /**
    * Asset ID of the holding.
    */


### PR DESCRIPTION
* feat: Added createAsset method
* fix: Updating asset-transfer-transaction.amount and .closeAmount to allow bigint values since they can be 64-bit numbers

BREAKING CHANGE: Indexer's from algokit.getAlgoIndexerClient(...) now have IntDecoding.MIXED rather than IntDecoding.DEFAULT
so that numbers > 53-bit will be accurately represented, you can override this with a new parameter to that function.

Also, a number of fields in types/indexer that can have 64-bit values have been changed from `number` to `number | bigint`.
