### PR TITLE
fix: match the previous getTestAccount behaviour when no kmd client is supplied

### DIFF
--- a/docs/code/modules/testing.md
+++ b/docs/code/modules/testing.md
@@ -159,7 +159,7 @@ ___
 | :------ | :------ | :------ |
 | `params` | [`GetTestAccountParams`](../interfaces/types_testing.GetTestAccountParams.md) | The config for the test account to generate |
 | `algod` | `default` | An algod client |
-| `kmd?` | `default` | A KMD client, if not specified then a default KMD client will be loaded from environment variables |
+| `kmd?` | `default` | A KMD client, if not specified then a default KMD client will be loaded from environment variables and if not found fallback to the default LocalNet KMD client |
 
 #### Returns
 

--- a/docs/code/modules/testing.md
+++ b/docs/code/modules/testing.md
@@ -178,7 +178,7 @@ Note: By default this will log the mnemonic of the account.
 
 #### Defined in
 
-[src/testing/account.ts:20](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/testing/account.ts#L20)
+[src/testing/account.ts:21](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/testing/account.ts#L21)
 
 ▸ **getTestAccount**(`params`, `algorand`): `Promise`\<`Account`\>
 
@@ -202,7 +202,7 @@ The account, with private key loaded
 
 #### Defined in
 
-[src/testing/account.ts:30](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/testing/account.ts#L30)
+[src/testing/account.ts:31](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/testing/account.ts#L31)
 
 ___
 

--- a/src/testing/account.ts
+++ b/src/testing/account.ts
@@ -1,5 +1,6 @@
 import algosdk from 'algosdk'
 import { AlgorandClient, Config } from '../'
+import { ClientManager } from '../types/client-manager'
 import { GetTestAccountParams } from '../types/testing'
 import Account = algosdk.Account
 import Algodv2 = algosdk.Algodv2
@@ -36,7 +37,11 @@ export async function getTestAccount(
   const algorand =
     algodOrAlgorandClient instanceof AlgorandClient
       ? algodOrAlgorandClient
-      : AlgorandClient.fromClients({ algod: algodOrAlgorandClient, kmd })
+      : AlgorandClient.fromClients({
+          algod: algodOrAlgorandClient,
+          kmd:
+            kmd ?? ClientManager.getKmdClient({ ...ClientManager.getAlgodConfigFromEnvironment(), port: process?.env?.KMD_PORT ?? '4002' }),
+        })
 
   const account = accountGetter ? await accountGetter(algorand) : algosdk.generateAccount()
 

--- a/src/testing/account.ts
+++ b/src/testing/account.ts
@@ -15,7 +15,7 @@ import Kmd = algosdk.Kmd
  * Note: By default this will log the mnemonic of the account.
  * @param params The config for the test account to generate
  * @param algod An algod client
- * @param kmd A KMD client, if not specified then a default KMD client will be loaded from environment variables
+ * @param kmd A KMD client, if not specified then a default KMD client will be loaded from environment variables and if not found fallback to the default LocalNet KMD client
  * @returns The account, with private key loaded
  */
 export async function getTestAccount(params: GetTestAccountParams, algod: Algodv2, kmd?: Kmd): Promise<Account>
@@ -34,13 +34,18 @@ export async function getTestAccount(
   algodOrAlgorandClient: Algodv2 | AlgorandClient,
   kmd?: Kmd,
 ): Promise<Account> {
+  let kmdClient = kmd
+  if (!kmdClient) {
+    const kmdConfig = ClientManager.getConfigFromEnvironmentOrLocalNet().kmdConfig
+    kmdClient = kmdConfig ? ClientManager.getKmdClient(kmdConfig) : undefined
+  }
+
   const algorand =
     algodOrAlgorandClient instanceof AlgorandClient
       ? algodOrAlgorandClient
       : AlgorandClient.fromClients({
           algod: algodOrAlgorandClient,
-          kmd:
-            kmd ?? ClientManager.getKmdClient({ ...ClientManager.getAlgodConfigFromEnvironment(), port: process?.env?.KMD_PORT ?? '4002' }),
+          kmd: kmdClient,
         })
 
   const account = accountGetter ? await accountGetter(algorand) : algosdk.generateAccount()


### PR DESCRIPTION
Realised I hadn't confirmed the new behaviour when kmd wasn't supplied.
Turns out it throws, which wasn't as per the documented behaviour.

This PR updates the obsoleted `getTestAccount` to have the same behaviour as before.