### PR TITLE
feat: allow bytes substitution for uint64 template vars

### DIFF
--- a/docs/code/modules/index.md
+++ b/docs/code/modules/index.md
@@ -2466,7 +2466,7 @@ The information about the compiled code
 
 #### Defined in
 
-[src/app-deploy.ts:616](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app-deploy.ts#L616)
+[src/app-deploy.ts:625](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app-deploy.ts#L625)
 
 ___
 
@@ -2823,7 +2823,7 @@ The TEAL without comments
 
 #### Defined in
 
-[src/app-deploy.ts:639](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app-deploy.ts#L639)
+[src/app-deploy.ts:648](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app-deploy.ts#L648)
 
 ___
 

--- a/src/app-deploy.spec.ts
+++ b/src/app-deploy.spec.ts
@@ -588,6 +588,27 @@ test('Can substitute template variable with multiple underscores', async () => {
   `)
 })
 
+test('Can substitue both bytes and int uint64', async () => {
+  const test_teal = `
+  int TMPL_SOME_VALUE
+  pushint TMPL_SOME_VALUE
+  bytes TMPL_SOME_VALUE
+  pushbytes TMPL_SOME_VALUE
+  return
+  `
+  const test_params = {
+    SOME_VALUE: 123,
+  }
+  const substituted = algokit.performTemplateSubstitution(test_teal, test_params)
+  expect(substituted).toBe(`
+  int 123
+  pushint 123
+  bytes 0x000000000000007b
+  pushbytes 0x000000000000007b
+  return
+  `)
+})
+
 function getMetadata(overrides?: Partial<AppDeployMetadata>): AppDeployMetadata {
   return {
     name: 'test',

--- a/src/app-deploy.ts
+++ b/src/app-deploy.ts
@@ -588,6 +588,15 @@ export function performTemplateSubstitution(tealCode: string, templateParams?: T
     for (const key in templateParams) {
       const value = templateParams[key]
       const token = `TMPL_${key.replace(/^TMPL_/, '')}`
+
+      // If this is a number, first replace any byte representations of the number
+      // These may appear in the TEAL in order to circumvent int compression and preserve PC values
+      if (typeof value === 'number' || typeof value === 'boolean') {
+        tealCode = tealCode.replace(new RegExp(`(?<=bytes )${token}`, 'g'), `0x${value.toString(16).padStart(16, '0')}`)
+
+        // We could probably return here since mixing pushint and pushbytes is likely not going to happen, but might as well do both
+      }
+
       tealCode = tealCode.replace(
         new RegExp(token, 'g'),
         typeof value === 'string'


### PR DESCRIPTION
## Proposed Changes

- The AVM compresses integers meaning uint64 template variables might have an unknown width when used with `pushint`. This PR allows the given TEAL to use `pushbytes` or `bytes` for uint64 template variables which will preserve the integer width. This will allow PC mapping to stay consistent between initial compile time and deployment. 

For an example of how a compiler might output TEAL, see https://github.com/algorandfoundation/TEALScript/pull/522/files

Assuming no objections, a similar PR will need to be made for py as well
