### PR TITLE
chore: update algosdk2 to the latest version

### DIFF
--- a/docs/code/classes/types_app_arc56.Arc56Method.md
+++ b/docs/code/classes/types_app_arc56.Arc56Method.md
@@ -22,8 +22,10 @@ Wrapper around `algosdk.ABIMethod` that represents an ARC-56 ABI method.
 
 - [args](types_app_arc56.Arc56Method.md#args)
 - [description](types_app_arc56.Arc56Method.md#description)
+- [events](types_app_arc56.Arc56Method.md#events)
 - [method](types_app_arc56.Arc56Method.md#method)
 - [name](types_app_arc56.Arc56Method.md#name)
+- [readonly](types_app_arc56.Arc56Method.md#readonly)
 - [returns](types_app_arc56.Arc56Method.md#returns)
 
 ### Methods
@@ -84,7 +86,21 @@ algosdk.ABIMethod.description
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:23
+node_modules/algosdk/dist/types/abi/method.d.ts:28
+
+___
+
+### events
+
+• `Optional` `Readonly` **events**: `ARC28Event`[]
+
+#### Inherited from
+
+algosdk.ABIMethod.events
+
+#### Defined in
+
+node_modules/algosdk/dist/types/abi/method.d.ts:38
 
 ___
 
@@ -108,7 +124,21 @@ algosdk.ABIMethod.name
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:22
+node_modules/algosdk/dist/types/abi/method.d.ts:27
+
+___
+
+### readonly
+
+• `Optional` `Readonly` **readonly**: `boolean`
+
+#### Inherited from
+
+algosdk.ABIMethod.readonly
+
+#### Defined in
+
+node_modules/algosdk/dist/types/abi/method.d.ts:39
 
 ___
 
@@ -148,7 +178,7 @@ algosdk.ABIMethod.getSelector
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:35
+node_modules/algosdk/dist/types/abi/method.d.ts:42
 
 ___
 
@@ -166,7 +196,7 @@ algosdk.ABIMethod.getSignature
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:34
+node_modules/algosdk/dist/types/abi/method.d.ts:41
 
 ___
 
@@ -202,7 +232,7 @@ algosdk.ABIMethod.txnCount
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:36
+node_modules/algosdk/dist/types/abi/method.d.ts:43
 
 ___
 
@@ -226,4 +256,4 @@ algosdk.ABIMethod.fromSignature
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:38
+node_modules/algosdk/dist/types/abi/method.d.ts:45

--- a/docs/code/modules/index.md
+++ b/docs/code/modules/index.md
@@ -1127,7 +1127,7 @@ const accountInfo = await account.getAccountAssetInformation(address, assetId, a
 
 #### Defined in
 
-[src/account/account.ts:194](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/account/account.ts#L194)
+[src/account/account.ts:196](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/account/account.ts#L196)
 
 ___
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@tsconfig/node20": "^20.1.4",
         "@types/jest": "^29.5.2",
         "@types/uuid": "^9.0.2",
-        "algosdk": "^2.7.0",
+        "algosdk": ">=2.9.0 <3.0",
         "better-npm-audit": "^3.7.3",
         "conventional-changelog-conventionalcommits": "6.1.0",
         "cpy-cli": "^5.0.0",
@@ -50,7 +50,7 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "algosdk": "^2.7.0"
+        "algosdk": ">=2.9.0 <3.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3229,9 +3229,9 @@
       }
     },
     "node_modules/algosdk": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.7.0.tgz",
-      "integrity": "sha512-sBE9lpV7bup3rZ+q2j3JQaFAE9JwZvjWKX00vPlG8e9txctXbgLL56jZhSWZndqhDI9oI+0P4NldkuQIWdrUyg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.9.0.tgz",
+      "integrity": "sha512-o0n0nLMbTX6SFQdMUk2/2sy50jmEmZk5OTPYSh2aAeP8DUPxrhjMPfwGsYNvaO+qk75MixC2eWpfA9vygCQ/Mg==",
       "dev": true,
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build:0-clean": "rimraf dist coverage",
     "build:1-compile": "rollup -c --configPlugin typescript",
     "build:3-copy-pkg-json": "npx --yes @makerx/ts-toolkit@latest copy-package-json --custom-sections module main type types exports",
-    "build:4-copy-readme": "cpy README.md LICENSE dist",
+    "build:4-copy-readme": "cpy README.md dist",
     "test": "dotenv -e .env -- jest --coverage --passWithNoTests --silent",
     "lint": "eslint ./src/ --ext .ts",
     "lint:fix": "eslint ./src/ --ext .ts --fix",
@@ -61,7 +61,7 @@
     "buffer": "^6.0.3"
   },
   "peerDependencies": {
-    "algosdk": "^2.7.0"
+    "algosdk": ">=2.9.0 <3.0"
   },
   "devDependencies": {
     "@algorandfoundation/tealscript": "^0.90.3",
@@ -75,7 +75,7 @@
     "@tsconfig/node20": "^20.1.4",
     "@types/jest": "^29.5.2",
     "@types/uuid": "^9.0.2",
-    "algosdk": "^2.7.0",
+    "algosdk": ">=2.9.0 <3.0",
     "better-npm-audit": "^3.7.3",
     "conventional-changelog-conventionalcommits": "6.1.0",
     "cpy-cli": "^5.0.0",

--- a/src/account/account.ts
+++ b/src/account/account.ts
@@ -166,10 +166,12 @@ export async function getAccountInformation(sender: string | SendTransactionFrom
     totalAssetsOptedIn: Number(account.totalAssetsOptedIn),
     totalCreatedApps: Number(account.totalCreatedApps),
     totalCreatedAssets: Number(account.totalCreatedAssets),
-    appsTotalExtraPages: account.appsTotalExtraPages ? Number(account.appsTotalExtraPages) : undefined,
-    rewardBase: account.rewardBase ? Number(account.rewardBase) : undefined,
-    totalBoxBytes: account.totalBoxBytes ? Number(account.totalBoxBytes) : undefined,
-    totalBoxes: account.totalBoxes ? Number(account.totalBoxes) : undefined,
+    appsTotalExtraPages: account.appsTotalExtraPages !== undefined ? Number(account.appsTotalExtraPages) : undefined,
+    rewardBase: account.rewardBase !== undefined ? Number(account.rewardBase) : undefined,
+    totalBoxBytes: account.totalBoxBytes !== undefined ? Number(account.totalBoxBytes) : undefined,
+    totalBoxes: account.totalBoxes !== undefined ? Number(account.totalBoxes) : undefined,
+    lastHeartbeat: account.lastHeartbeat !== undefined ? Number(account.lastHeartbeat) : undefined,
+    lastProposed: account.lastProposed !== undefined ? Number(account.lastProposed) : undefined,
   }
 }
 


### PR DESCRIPTION
algosdk@2.9.0 has support in their simulate models for `fixSigners`, which we want to use in lora. See https://github.com/algorand/go-algorand/pull/5942