### PR TITLE
feta: support fix signers in simulate

### DIFF
--- a/docs/code/classes/types_account_manager.AccountManager.md
+++ b/docs/code/classes/types_account_manager.AccountManager.md
@@ -177,7 +177,7 @@ ___
 
 #### Defined in
 
-[src/types/account-manager.ts:495](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L495)
+[src/types/account-manager.ts:502](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L502)
 
 ___
 
@@ -207,7 +207,7 @@ const account = await account.dispenserFromEnvironment()
 
 #### Defined in
 
-[src/types/account-manager.ts:408](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L408)
+[src/types/account-manager.ts:415](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L415)
 
 ___
 
@@ -250,7 +250,7 @@ await algorand.account.ensureFunded("ACCOUNTADDRESS", "DISPENSERADDRESS", algoki
 
 #### Defined in
 
-[src/types/account-manager.ts:528](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L528)
+[src/types/account-manager.ts:535](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L535)
 
 ___
 
@@ -299,7 +299,7 @@ await algorand.account.ensureFundedFromEnvironment("ACCOUNTADDRESS", algokit.alg
 
 #### Defined in
 
-[src/types/account-manager.ts:590](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L590)
+[src/types/account-manager.ts:597](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L597)
 
 ___
 
@@ -343,7 +343,7 @@ await algorand.account.ensureFundedUsingDispenserAPI("ACCOUNTADDRESS", algorand.
 
 #### Defined in
 
-[src/types/account-manager.ts:646](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L646)
+[src/types/account-manager.ts:653](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L653)
 
 ___
 
@@ -388,7 +388,7 @@ If not running against LocalNet then it will use proces.env.MY_ACCOUNT_MNEMONIC 
 
 #### Defined in
 
-[src/types/account-manager.ts:301](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L301)
+[src/types/account-manager.ts:308](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L308)
 
 ___
 
@@ -422,7 +422,7 @@ const defaultDispenserAccount = await account.fromKmd('unencrypted-default-walle
 
 #### Defined in
 
-[src/types/account-manager.ts:337](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L337)
+[src/types/account-manager.ts:344](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L344)
 
 ___
 
@@ -454,7 +454,7 @@ const rekeyedAccount = accountManager.fromMnemonic("mnemonic secret ...", "SENDE
 
 #### Defined in
 
-[src/types/account-manager.ts:253](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L253)
+[src/types/account-manager.ts:260](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L260)
 
 ___
 
@@ -579,7 +579,7 @@ const account = await account.localNetDispenser()
 
 #### Defined in
 
-[src/types/account-manager.ts:427](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L427)
+[src/types/account-manager.ts:434](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L434)
 
 ___
 
@@ -610,7 +610,7 @@ const account = account.logicsig(program, [new Uint8Array(3, ...)])
 
 #### Defined in
 
-[src/types/account-manager.ts:375](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L375)
+[src/types/account-manager.ts:382](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L382)
 
 ___
 
@@ -642,7 +642,7 @@ const account = accountManager.multisig({version: 1, threshold: 1, addrs: ["ADDR
 
 #### Defined in
 
-[src/types/account-manager.ts:360](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L360)
+[src/types/account-manager.ts:367](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L367)
 
 ___
 
@@ -666,7 +666,7 @@ const account = account.random()
 
 #### Defined in
 
-[src/types/account-manager.ts:388](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L388)
+[src/types/account-manager.ts:395](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L395)
 
 ___
 
@@ -726,7 +726,7 @@ await algorand.account.rekeyAccount({
 
 #### Defined in
 
-[src/types/account-manager.ts:470](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L470)
+[src/types/account-manager.ts:477](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L477)
 
 ___
 
@@ -758,7 +758,7 @@ const rekeyedAccount = accountManager.rekeyed(account, "SENDERADDRESS...")
 
 #### Defined in
 
-[src/types/account-manager.ts:270](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L270)
+[src/types/account-manager.ts:277](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account-manager.ts#L277)
 
 ___
 

--- a/docs/code/classes/types_app_arc56.Arc56Method.md
+++ b/docs/code/classes/types_app_arc56.Arc56Method.md
@@ -22,8 +22,10 @@ Wrapper around `algosdk.ABIMethod` that represents an ARC-56 ABI method.
 
 - [args](types_app_arc56.Arc56Method.md#args)
 - [description](types_app_arc56.Arc56Method.md#description)
+- [events](types_app_arc56.Arc56Method.md#events)
 - [method](types_app_arc56.Arc56Method.md#method)
 - [name](types_app_arc56.Arc56Method.md#name)
+- [readonly](types_app_arc56.Arc56Method.md#readonly)
 - [returns](types_app_arc56.Arc56Method.md#returns)
 
 ### Methods
@@ -84,7 +86,21 @@ algosdk.ABIMethod.description
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:23
+node_modules/algosdk/dist/types/abi/method.d.ts:28
+
+___
+
+### events
+
+• `Optional` `Readonly` **events**: `ARC28Event`[]
+
+#### Inherited from
+
+algosdk.ABIMethod.events
+
+#### Defined in
+
+node_modules/algosdk/dist/types/abi/method.d.ts:38
 
 ___
 
@@ -108,7 +124,21 @@ algosdk.ABIMethod.name
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:22
+node_modules/algosdk/dist/types/abi/method.d.ts:27
+
+___
+
+### readonly
+
+• `Optional` `Readonly` **readonly**: `boolean`
+
+#### Inherited from
+
+algosdk.ABIMethod.readonly
+
+#### Defined in
+
+node_modules/algosdk/dist/types/abi/method.d.ts:39
 
 ___
 
@@ -148,7 +178,7 @@ algosdk.ABIMethod.getSelector
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:35
+node_modules/algosdk/dist/types/abi/method.d.ts:42
 
 ___
 
@@ -166,7 +196,7 @@ algosdk.ABIMethod.getSignature
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:34
+node_modules/algosdk/dist/types/abi/method.d.ts:41
 
 ___
 
@@ -202,7 +232,7 @@ algosdk.ABIMethod.txnCount
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:36
+node_modules/algosdk/dist/types/abi/method.d.ts:43
 
 ___
 
@@ -226,4 +256,4 @@ algosdk.ABIMethod.fromSignature
 
 #### Defined in
 
-node_modules/algosdk/dist/types/abi/method.d.ts:38
+node_modules/algosdk/dist/types/abi/method.d.ts:45

--- a/docs/code/classes/types_composer.default.md
+++ b/docs/code/classes/types_composer.default.md
@@ -1209,4 +1209,4 @@ The binary encoded transaction note
 
 #### Defined in
 
-[src/types/composer.ts:1365](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/composer.ts#L1365)
+[src/types/composer.ts:1367](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/composer.ts#L1367)

--- a/docs/code/interfaces/types_account.AccountConfig.md
+++ b/docs/code/interfaces/types_account.AccountConfig.md
@@ -28,7 +28,7 @@ Mnemonic for an account
 
 #### Defined in
 
-[src/types/account.ts:279](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account.ts#L279)
+[src/types/account.ts:290](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account.ts#L290)
 
 ___
 
@@ -40,7 +40,7 @@ Account name used to retrieve config
 
 #### Defined in
 
-[src/types/account.ts:283](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account.ts#L283)
+[src/types/account.ts:294](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account.ts#L294)
 
 ___
 
@@ -52,7 +52,7 @@ Address of a rekeyed account
 
 #### Defined in
 
-[src/types/account.ts:281](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account.ts#L281)
+[src/types/account.ts:292](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account.ts#L292)
 
 ___
 
@@ -66,4 +66,4 @@ Renamed to senderAddress in 2.3.1
 
 #### Defined in
 
-[src/types/account.ts:286](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account.ts#L286)
+[src/types/account.ts:297](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account.ts#L297)

--- a/docs/code/modules/index.md
+++ b/docs/code/modules/index.md
@@ -1127,7 +1127,7 @@ const accountInfo = await account.getAccountAssetInformation(address, assetId, a
 
 #### Defined in
 
-[src/account/account.ts:194](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/account/account.ts#L194)
+[src/account/account.ts:196](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/account/account.ts#L196)
 
 ___
 

--- a/docs/code/modules/index.md
+++ b/docs/code/modules/index.md
@@ -557,7 +557,7 @@ the estimated rate.
 
 #### Defined in
 
-[src/transaction/transaction.ts:879](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L879)
+[src/transaction/transaction.ts:862](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L862)
 
 ___
 
@@ -621,7 +621,7 @@ Allows for control of fees on a `Transaction` or `SuggestedParams` object
 
 #### Defined in
 
-[src/transaction/transaction.ts:904](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L904)
+[src/transaction/transaction.ts:887](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L887)
 
 ___
 
@@ -948,7 +948,7 @@ Converts `bigint`'s for Uint's < 64 to `number` for easier use.
 
 #### Defined in
 
-[src/transaction/transaction.ts:729](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L729)
+[src/transaction/transaction.ts:712](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L712)
 
 ___
 
@@ -1931,7 +1931,7 @@ Returns the array of transactions currently present in the given `AtomicTransact
 
 #### Defined in
 
-[src/transaction/transaction.ts:940](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L940)
+[src/transaction/transaction.ts:923](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L923)
 
 ___
 
@@ -2318,7 +2318,7 @@ Returns suggested transaction parameters from algod unless some are already prov
 
 #### Defined in
 
-[src/transaction/transaction.ts:929](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L929)
+[src/transaction/transaction.ts:912](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L912)
 
 ___
 
@@ -2635,7 +2635,7 @@ Performs a dry run of the transactions loaded into the given AtomicTransactionCo
 
 #### Defined in
 
-[src/transaction/transaction.ts:755](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L755)
+[src/transaction/transaction.ts:738](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L738)
 
 ___
 
@@ -2778,7 +2778,7 @@ A new ATC with the resources packed into the transactions
 
 #### Defined in
 
-[src/transaction/transaction.ts:329](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L329)
+[src/transaction/transaction.ts:312](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L312)
 
 ___
 
@@ -2928,7 +2928,7 @@ An object with transaction IDs, transactions, group transaction ID (`groupTransa
 
 #### Defined in
 
-[src/transaction/transaction.ts:580](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L580)
+[src/transaction/transaction.ts:563](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L563)
 
 ___
 
@@ -2957,7 +2957,7 @@ Signs and sends a group of [up to 16](https://developer.algorand.org/docs/get-de
 
 #### Defined in
 
-[src/transaction/transaction.ts:775](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L775)
+[src/transaction/transaction.ts:758](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L758)
 
 ___
 
@@ -3230,4 +3230,4 @@ Throws an error if the transaction is not confirmed or rejected in the next `tim
 
 #### Defined in
 
-[src/transaction/transaction.ts:820](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L820)
+[src/transaction/transaction.ts:803](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/transaction/transaction.ts#L803)

--- a/docs/code/modules/types_account.md
+++ b/docs/code/modules/types_account.md
@@ -42,7 +42,7 @@ Account asset holding information at a given round.
 
 #### Defined in
 
-[src/types/account.ts:263](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account.ts#L263)
+[src/types/account.ts:274](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/account.ts#L274)
 
 ___
 
@@ -66,6 +66,8 @@ Account information at a given round.
 | `balance` | [`AlgoAmount`](../classes/types_amount.AlgoAmount.md) | The balance of Algo currently held by the account. |
 | `createdApps?` | `Application`[] | Parameters of applications created by this account including app global data. |
 | `createdAssets?` | `Asset`[] | (apar) parameters of assets created by this account. Note: the raw account uses `map[int] -> Asset` for this type. |
+| `lastHeartbeatRound?` | `bigint` | The round in which this account last went online, or explicitly renewed their online status. |
+| `lastProposedRound?` | `bigint` | The round in which this account last proposed the block. |
 | `minBalance` | [`AlgoAmount`](../classes/types_amount.AlgoAmount.md) | Algo balance required to be held by the account. The requirement grows based on asset and application usage. |
 | `participation?` | `AccountParticipation` | AccountParticipation describes the parameters used by this account in consensus protocol. |
 | `pendingRewards` | [`AlgoAmount`](../classes/types_amount.AlgoAmount.md) | Amount of Algo of pending rewards in this account. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@tsconfig/node20": "^20.1.4",
         "@types/jest": "^29.5.2",
         "@types/uuid": "^9.0.2",
-        "algosdk": "^2.7.0",
+        "algosdk": ">=2.9.0 <3.0",
         "better-npm-audit": "^3.7.3",
         "conventional-changelog-conventionalcommits": "6.1.0",
         "cpy-cli": "^5.0.0",
@@ -50,7 +50,7 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "algosdk": "^2.7.0"
+        "algosdk": ">=2.9.0 <3.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3230,9 +3230,9 @@
       }
     },
     "node_modules/algosdk": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.7.0.tgz",
-      "integrity": "sha512-sBE9lpV7bup3rZ+q2j3JQaFAE9JwZvjWKX00vPlG8e9txctXbgLL56jZhSWZndqhDI9oI+0P4NldkuQIWdrUyg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.9.0.tgz",
+      "integrity": "sha512-o0n0nLMbTX6SFQdMUk2/2sy50jmEmZk5OTPYSh2aAeP8DUPxrhjMPfwGsYNvaO+qk75MixC2eWpfA9vygCQ/Mg==",
       "dev": true,
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "buffer": "^6.0.3"
   },
   "peerDependencies": {
-    "algosdk": "^2.7.0"
+    "algosdk": ">=2.9.0 <3.0"
   },
   "devDependencies": {
     "@algorandfoundation/tealscript": "^0.105.3",
@@ -75,7 +75,7 @@
     "@tsconfig/node20": "^20.1.4",
     "@types/jest": "^29.5.2",
     "@types/uuid": "^9.0.2",
-    "algosdk": "^2.7.0",
+    "algosdk": ">=2.9.0 <3.0",
     "better-npm-audit": "^3.7.3",
     "conventional-changelog-conventionalcommits": "6.1.0",
     "cpy-cli": "^5.0.0",

--- a/src/account/account.ts
+++ b/src/account/account.ts
@@ -166,10 +166,12 @@ export async function getAccountInformation(sender: string | SendTransactionFrom
     totalAssetsOptedIn: Number(account.totalAssetsOptedIn),
     totalCreatedApps: Number(account.totalCreatedApps),
     totalCreatedAssets: Number(account.totalCreatedAssets),
-    appsTotalExtraPages: account.appsTotalExtraPages ? Number(account.appsTotalExtraPages) : undefined,
-    rewardBase: account.rewardBase ? Number(account.rewardBase) : undefined,
-    totalBoxBytes: account.totalBoxBytes ? Number(account.totalBoxBytes) : undefined,
-    totalBoxes: account.totalBoxes ? Number(account.totalBoxes) : undefined,
+    appsTotalExtraPages: account.appsTotalExtraPages !== undefined ? Number(account.appsTotalExtraPages) : undefined,
+    rewardBase: account.rewardBase !== undefined ? Number(account.rewardBase) : undefined,
+    totalBoxBytes: account.totalBoxBytes !== undefined ? Number(account.totalBoxBytes) : undefined,
+    totalBoxes: account.totalBoxes !== undefined ? Number(account.totalBoxes) : undefined,
+    lastHeartbeat: account.lastHeartbeat !== undefined ? Number(account.lastHeartbeat) : undefined,
+    lastProposed: account.lastProposed !== undefined ? Number(account.lastProposed) : undefined,
   }
 }
 

--- a/src/transaction/perform-atomic-transaction-composer-simulate.ts
+++ b/src/transaction/perform-atomic-transaction-composer-simulate.ts
@@ -16,6 +16,7 @@ export async function performAtomicTransactionComposerSimulate(atc: AtomicTransa
 
   const simulateRequest = new modelsv2.SimulateRequest({
     allowEmptySignatures: true,
+    fixSigners: true,
     allowMoreLogging: true,
     execTraceConfig: new modelsv2.SimulateTraceConfig({
       enable: true,

--- a/src/types/account-manager.ts
+++ b/src/types/account-manager.ts
@@ -213,27 +213,34 @@ export class AccountManager {
    * @returns The account information
    */
   public async getInformation(sender: string | TransactionSignerAccount): Promise<AccountInformation> {
-    const account = AccountInformationModel.from_obj_for_encoding(
+    const {
+      round,
+      lastHeartbeat = undefined,
+      lastProposed = undefined,
+      ...account
+    } = AccountInformationModel.from_obj_for_encoding(
       await this._clientManager.algod.accountInformation(typeof sender === 'string' ? sender : sender.addr).do(),
     )
 
     return {
       ...account,
-      // None of these can practically overflow 2^53
+      // None of the Number types can practically overflow 2^53
       balance: AlgoAmount.MicroAlgo(Number(account.amount)),
       amountWithoutPendingRewards: AlgoAmount.MicroAlgo(Number(account.amountWithoutPendingRewards)),
       minBalance: AlgoAmount.MicroAlgo(Number(account.minBalance)),
       pendingRewards: AlgoAmount.MicroAlgo(Number(account.pendingRewards)),
       rewards: AlgoAmount.MicroAlgo(Number(account.rewards)),
-      validAsOfRound: BigInt(account.round),
+      validAsOfRound: BigInt(round),
       totalAppsOptedIn: Number(account.totalAppsOptedIn),
       totalAssetsOptedIn: Number(account.totalAssetsOptedIn),
       totalCreatedApps: Number(account.totalCreatedApps),
       totalCreatedAssets: Number(account.totalCreatedAssets),
-      appsTotalExtraPages: account.appsTotalExtraPages ? Number(account.appsTotalExtraPages) : undefined,
-      rewardBase: account.rewardBase ? Number(account.rewardBase) : undefined,
-      totalBoxBytes: account.totalBoxBytes ? Number(account.totalBoxBytes) : undefined,
-      totalBoxes: account.totalBoxes ? Number(account.totalBoxes) : undefined,
+      appsTotalExtraPages: account.appsTotalExtraPages !== undefined ? Number(account.appsTotalExtraPages) : undefined,
+      rewardBase: account.rewardBase !== undefined ? Number(account.rewardBase) : undefined,
+      totalBoxBytes: account.totalBoxBytes !== undefined ? Number(account.totalBoxBytes) : undefined,
+      totalBoxes: account.totalBoxes !== undefined ? Number(account.totalBoxes) : undefined,
+      lastHeartbeatRound: lastHeartbeat !== undefined ? BigInt(lastHeartbeat) : undefined,
+      lastProposedRound: lastProposed !== undefined ? BigInt(lastProposed) : undefined,
     }
   }
 

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -257,6 +257,17 @@ export type AccountInformation = {
    * The number of existing boxes created by this account's app.
    */
   totalBoxes?: number
+
+  /**
+   * The round in which this account last went online, or explicitly renewed their
+   * online status.
+   */
+  lastHeartbeatRound?: bigint
+
+  /**
+   * The round in which this account last proposed the block.
+   */
+  lastProposedRound?: bigint
 }
 
 /** Account asset holding information at a given round. */

--- a/src/types/composer.ts
+++ b/src/types/composer.ts
@@ -1295,6 +1295,7 @@ export default class TransactionComposer {
     // Build the transactions
     if (options?.skipSignatures) {
       options.allowEmptySignatures = true
+      options.fixSigners = true
       // Build transactions uses empty signers
       const transactions = await this.buildTransactions()
       for (const txn of transactions.transactions) {
@@ -1314,6 +1315,7 @@ export default class TransactionComposer {
         ...(Config.debug
           ? {
               allowEmptySignatures: true,
+              fixSigners: true,
               allowMoreLogging: true,
               execTraceConfig: new modelsv2.SimulateTraceConfig({
                 enable: true,


### PR DESCRIPTION
Now that 3.26 is on mainnet, we can use `fixSigners` when running a simulate.
This PR also removes the previous workaround.