### PR TITLE
feat: add support for abi methods calls as default values

### DIFF
--- a/docs/code/classes/types_app_arc56.Arc56Method.md
+++ b/docs/code/classes/types_app_arc56.Arc56Method.md
@@ -64,7 +64,7 @@ algosdk.ABIMethod.constructor
 
 ### args
 
-• `Readonly` **args**: \{ `defaultValue?`: \{ `data`: `string` \| `number` ; `source`: ``"box"`` \| ``"global"`` \| ``"local"`` \| ``"literal"`` ; `type`: `string`  } ; `desc?`: `string` ; `name?`: `string` ; `struct?`: `string` ; `type`: `ABIArgumentType`  }[]
+• `Readonly` **args**: \{ `defaultValue?`: \{ `data`: `string` ; `source`: ``"method"`` \| ``"box"`` \| ``"global"`` \| ``"local"`` \| ``"literal"`` ; `type?`: `string`  } ; `desc?`: `string` ; `name?`: `string` ; `struct?`: `string` ; `type`: `ABIArgumentType`  }[]
 
 #### Overrides
 

--- a/docs/code/classes/types_app_client.AppClient.md
+++ b/docs/code/classes/types_app_client.AppClient.md
@@ -304,7 +304,7 @@ A reference to the underlying `AlgorandClient` this app client is using.
 
 #### Defined in
 
-[src/types/app-client.ts:641](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L641)
+[src/types/app-client.ts:647](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L647)
 
 ___
 
@@ -320,7 +320,7 @@ The app address of the app instance this client is linked to.
 
 #### Defined in
 
-[src/types/app-client.ts:626](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L626)
+[src/types/app-client.ts:632](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L632)
 
 ___
 
@@ -336,7 +336,7 @@ The ID of the app instance this client is linked to.
 
 #### Defined in
 
-[src/types/app-client.ts:621](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L621)
+[src/types/app-client.ts:627](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L627)
 
 ___
 
@@ -352,7 +352,7 @@ The name of the app (from the ARC-32 / ARC-56 app spec).
 
 #### Defined in
 
-[src/types/app-client.ts:631](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L631)
+[src/types/app-client.ts:637](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L637)
 
 ___
 
@@ -368,7 +368,7 @@ The ARC-56 app spec being used
 
 #### Defined in
 
-[src/types/app-client.ts:636](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L636)
+[src/types/app-client.ts:642](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L642)
 
 ___
 
@@ -384,7 +384,7 @@ Create transactions for the current app
 
 #### Defined in
 
-[src/types/app-client.ts:665](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L665)
+[src/types/app-client.ts:671](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L671)
 
 ___
 
@@ -417,7 +417,7 @@ await appClient.send.call({method: 'my_method2', args: [myMethodCall]})
 
 #### Defined in
 
-[src/types/app-client.ts:660](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L660)
+[src/types/app-client.ts:666](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L666)
 
 ___
 
@@ -433,7 +433,7 @@ Send transactions to the current app
 
 #### Defined in
 
-[src/types/app-client.ts:670](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L670)
+[src/types/app-client.ts:676](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L676)
 
 ___
 
@@ -463,7 +463,7 @@ Get state (local, global, box) from the current app
 
 #### Defined in
 
-[src/types/app-client.ts:675](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L675)
+[src/types/app-client.ts:681](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L681)
 
 ## Methods
 
@@ -471,11 +471,13 @@ Get state (local, global, box) from the current app
 
 ▸ **clone**(`params`): [`AppClient`](types_app_client.AppClient.md)
 
+Clone this app client with different params
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `params` | `Object` | - |
+| `params` | `Object` | The params to use for the the cloned app client. Omit a param to keep the original value. Set a param to override the original value. Setting to undefined will clear the original value. |
 | `params.appId?` | `bigint` | The ID of the app instance this client should make calls against. |
 | `params.appName?` | `string` | Optional override for the app name; used for on-chain metadata and lookups. Defaults to the ARC-32/ARC-56 app spec name |
 | `params.approvalSourceMap?` | `SourceMap` | Optional source map for the approval program |
@@ -487,9 +489,11 @@ Get state (local, global, box) from the current app
 
 [`AppClient`](types_app_client.AppClient.md)
 
+A new app client with the altered params
+
 #### Defined in
 
-[src/types/app-client.ts:544](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L544)
+[src/types/app-client.ts:550](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L550)
 
 ___
 
@@ -517,7 +521,7 @@ Will store any generated source maps for later use in debugging.
 
 #### Defined in
 
-[src/types/app-client.ts:872](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L872)
+[src/types/app-client.ts:878](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L878)
 
 ___
 
@@ -535,7 +539,7 @@ The source maps
 
 #### Defined in
 
-[src/types/app-client.ts:813](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L813)
+[src/types/app-client.ts:819](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L819)
 
 ___
 
@@ -561,7 +565,7 @@ The new error, or if there was no logic error or source map then the wrapped err
 
 #### Defined in
 
-[src/types/app-client.ts:791](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L791)
+[src/types/app-client.ts:797](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L797)
 
 ___
 
@@ -603,7 +607,7 @@ The result of the funding
 
 #### Defined in
 
-[src/types/app-client.ts:700](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L700)
+[src/types/app-client.ts:706](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L706)
 
 ___
 
@@ -630,7 +634,7 @@ It does this by replacing any `undefined` values with the equivalent default val
 
 #### Defined in
 
-[src/types/app-client.ts:1029](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1029)
+[src/types/app-client.ts:1035](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1035)
 
 ___
 
@@ -654,7 +658,7 @@ A tuple with: [ARC-56 `Method`, algosdk `ABIMethod`]
 
 #### Defined in
 
-[src/types/app-client.ts:841](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L841)
+[src/types/app-client.ts:847](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L847)
 
 ___
 
@@ -682,7 +686,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1399](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1399)
+[src/types/app-client.ts:1410](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1410)
 
 ___
 
@@ -705,7 +709,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1133](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1133)
+[src/types/app-client.ts:1144](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1144)
 
 ___
 
@@ -733,7 +737,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1386](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1386)
+[src/types/app-client.ts:1397](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1397)
 
 ___
 
@@ -756,7 +760,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1098](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1098)
+[src/types/app-client.ts:1109](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1109)
 
 ___
 
@@ -779,7 +783,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1162](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1162)
+[src/types/app-client.ts:1173](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1173)
 
 ___
 
@@ -800,7 +804,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1431](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1431)
+[src/types/app-client.ts:1442](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1442)
 
 ___
 
@@ -818,7 +822,7 @@ The names of the boxes
 
 #### Defined in
 
-[src/types/app-client.ts:725](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L725)
+[src/types/app-client.ts:731](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L731)
 
 ___
 
@@ -842,7 +846,7 @@ The current box value as a byte array
 
 #### Defined in
 
-[src/types/app-client.ts:734](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L734)
+[src/types/app-client.ts:740](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L740)
 
 ___
 
@@ -867,7 +871,7 @@ The current box value as a byte array
 
 #### Defined in
 
-[src/types/app-client.ts:744](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L744)
+[src/types/app-client.ts:750](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L750)
 
 ___
 
@@ -892,7 +896,7 @@ The (name, value) pair of the boxes with values as raw byte arrays
 
 #### Defined in
 
-[src/types/app-client.ts:758](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L758)
+[src/types/app-client.ts:764](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L764)
 
 ___
 
@@ -918,7 +922,7 @@ The (name, value) pair of the boxes with values as the ABI Value
 
 #### Defined in
 
-[src/types/app-client.ts:774](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L774)
+[src/types/app-client.ts:780](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L780)
 
 ___
 
@@ -936,7 +940,7 @@ The global state
 
 #### Defined in
 
-[src/types/app-client.ts:708](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L708)
+[src/types/app-client.ts:714](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L714)
 
 ___
 
@@ -960,7 +964,7 @@ The local state
 
 #### Defined in
 
-[src/types/app-client.ts:717](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L717)
+[src/types/app-client.ts:723](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L723)
 
 ___
 
@@ -983,7 +987,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1328](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1328)
+[src/types/app-client.ts:1339](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1339)
 
 ___
 
@@ -1006,7 +1010,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1195](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1195)
+[src/types/app-client.ts:1206](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1206)
 
 ___
 
@@ -1029,7 +1033,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1235](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1235)
+[src/types/app-client.ts:1246](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1246)
 
 ___
 
@@ -1052,7 +1056,7 @@ if none provided and throws an error if neither provided
 
 #### Defined in
 
-[src/types/app-client.ts:1369](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1369)
+[src/types/app-client.ts:1380](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1380)
 
 ___
 
@@ -1077,7 +1081,7 @@ or `undefined` otherwise (so the signer is resolved from `AlgorandClient`)
 
 #### Defined in
 
-[src/types/app-client.ts:1379](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1379)
+[src/types/app-client.ts:1390](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1390)
 
 ___
 
@@ -1106,7 +1110,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1503](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1503)
+[src/types/app-client.ts:1514](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1514)
 
 ___
 
@@ -1134,7 +1138,7 @@ Make the given call and catch any errors, augmenting with debugging information 
 
 #### Defined in
 
-[src/types/app-client.ts:1423](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1423)
+[src/types/app-client.ts:1434](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1434)
 
 ___
 
@@ -1156,7 +1160,7 @@ Import source maps for the app.
 
 #### Defined in
 
-[src/types/app-client.ts:830](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L830)
+[src/types/app-client.ts:836](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L836)
 
 ___
 
@@ -1172,7 +1176,7 @@ Start a new `TransactionComposer` transaction group
 
 #### Defined in
 
-[src/types/app-client.ts:559](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L559)
+[src/types/app-client.ts:565](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L565)
 
 ___
 
@@ -1207,7 +1211,7 @@ The smart contract response with an updated return value
 
 #### Defined in
 
-[src/types/app-client.ts:855](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L855)
+[src/types/app-client.ts:861](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L861)
 
 ___
 
@@ -1237,7 +1241,7 @@ Will store any generated source maps for later use in debugging.
 
 #### Defined in
 
-[src/types/app-client.ts:976](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L976)
+[src/types/app-client.ts:982](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L982)
 
 ___
 
@@ -1270,7 +1274,7 @@ The new error, or if there was no logic error or source map then the wrapped err
 
 #### Defined in
 
-[src/types/app-client.ts:893](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L893)
+[src/types/app-client.ts:899](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L899)
 
 ___
 
@@ -1303,7 +1307,7 @@ using AlgoKit app deployment semantics (i.e. looking for the app creation transa
 
 #### Defined in
 
-[src/types/app-client.ts:568](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L568)
+[src/types/app-client.ts:574](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L574)
 
 ___
 
@@ -1335,7 +1339,7 @@ If no IDs are in the app spec or the network isn't recognised, an error is throw
 
 #### Defined in
 
-[src/types/app-client.ts:590](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L590)
+[src/types/app-client.ts:596](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L596)
 
 ___
 
@@ -1360,4 +1364,4 @@ The normalised ARC-56 contract object
 
 #### Defined in
 
-[src/types/app-client.ts:614](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L614)
+[src/types/app-client.ts:620](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L620)

--- a/docs/code/classes/types_app_client.ApplicationClient.md
+++ b/docs/code/classes/types_app_client.ApplicationClient.md
@@ -92,7 +92,7 @@ Create a new ApplicationClient instance
 
 #### Defined in
 
-[src/types/app-client.ts:1630](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1630)
+[src/types/app-client.ts:1641](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1641)
 
 ## Properties
 
@@ -102,7 +102,7 @@ Create a new ApplicationClient instance
 
 #### Defined in
 
-[src/types/app-client.ts:1613](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1613)
+[src/types/app-client.ts:1624](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1624)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1612](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1612)
+[src/types/app-client.ts:1623](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1623)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1615](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1615)
+[src/types/app-client.ts:1626](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1626)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1617](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1617)
+[src/types/app-client.ts:1628](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1628)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1618](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1618)
+[src/types/app-client.ts:1629](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1629)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1614](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1614)
+[src/types/app-client.ts:1625](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1625)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1604](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1604)
+[src/types/app-client.ts:1615](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1615)
 
 ___
 
@@ -172,7 +172,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1606](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1606)
+[src/types/app-client.ts:1617](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1617)
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1610](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1610)
+[src/types/app-client.ts:1621](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1621)
 
 ___
 
@@ -192,7 +192,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1609](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1609)
+[src/types/app-client.ts:1620](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1620)
 
 ___
 
@@ -202,7 +202,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1605](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1605)
+[src/types/app-client.ts:1616](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1616)
 
 ___
 
@@ -212,7 +212,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1608](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1608)
+[src/types/app-client.ts:1619](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1619)
 
 ___
 
@@ -222,7 +222,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1607](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1607)
+[src/types/app-client.ts:1618](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1618)
 
 ## Methods
 
@@ -250,7 +250,7 @@ Issues a no_op (normal) call to the app.
 
 #### Defined in
 
-[src/types/app-client.ts:1955](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1955)
+[src/types/app-client.ts:1966](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1966)
 
 ___
 
@@ -279,7 +279,7 @@ Issues a call to the app with the given call type.
 
 #### Defined in
 
-[src/types/app-client.ts:2038](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2038)
+[src/types/app-client.ts:2049](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2049)
 
 ___
 
@@ -307,7 +307,7 @@ Issues a clear_state call to the app.
 
 #### Defined in
 
-[src/types/app-client.ts:2015](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2015)
+[src/types/app-client.ts:2026](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2026)
 
 ___
 
@@ -335,7 +335,7 @@ Issues a close_out call to the app.
 
 #### Defined in
 
-[src/types/app-client.ts:2004](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2004)
+[src/types/app-client.ts:2015](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2015)
 
 ___
 
@@ -363,7 +363,7 @@ Compiles the approval and clear state programs and sets up the source map.
 
 #### Defined in
 
-[src/types/app-client.ts:1669](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1669)
+[src/types/app-client.ts:1680](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1680)
 
 ___
 
@@ -391,7 +391,7 @@ Creates a smart contract app, returns the details of the created app.
 
 #### Defined in
 
-[src/types/app-client.ts:1849](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1849)
+[src/types/app-client.ts:1860](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1860)
 
 ___
 
@@ -419,7 +419,7 @@ Issues a delete_application call to the app.
 
 #### Defined in
 
-[src/types/app-client.ts:2026](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2026)
+[src/types/app-client.ts:2037](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2037)
 
 ___
 
@@ -453,7 +453,7 @@ To understand the architecture decisions behind this functionality please see ht
 
 #### Defined in
 
-[src/types/app-client.ts:1737](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1737)
+[src/types/app-client.ts:1748](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1748)
 
 ___
 
@@ -471,7 +471,7 @@ The source maps
 
 #### Defined in
 
-[src/types/app-client.ts:1702](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1702)
+[src/types/app-client.ts:1713](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1713)
 
 ___
 
@@ -498,7 +498,7 @@ The new error, or if there was no logic error or source map then the wrapped err
 
 #### Defined in
 
-[src/types/app-client.ts:2362](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2362)
+[src/types/app-client.ts:2373](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2373)
 
 ___
 
@@ -522,7 +522,7 @@ The result of the funding
 
 #### Defined in
 
-[src/types/app-client.ts:2078](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2078)
+[src/types/app-client.ts:2089](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2089)
 
 ___
 
@@ -546,7 +546,7 @@ The ABI method for the given method
 
 #### Defined in
 
-[src/types/app-client.ts:2319](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2319)
+[src/types/app-client.ts:2330](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2330)
 
 ___
 
@@ -574,7 +574,7 @@ Returns the ABI Method parameters for the given method name string for the app r
 
 #### Defined in
 
-[src/types/app-client.ts:2297](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2297)
+[src/types/app-client.ts:2308](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2308)
 
 ___
 
@@ -594,7 +594,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:2379](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2379)
+[src/types/app-client.ts:2390](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2390)
 
 ___
 
@@ -617,7 +617,7 @@ Gets the reference information for the current application instance.
 
 #### Defined in
 
-[src/types/app-client.ts:2331](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2331)
+[src/types/app-client.ts:2342](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2342)
 
 ___
 
@@ -635,7 +635,7 @@ The names of the boxes
 
 #### Defined in
 
-[src/types/app-client.ts:2134](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2134)
+[src/types/app-client.ts:2145](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2145)
 
 ___
 
@@ -659,7 +659,7 @@ The current box value as a byte array
 
 #### Defined in
 
-[src/types/app-client.ts:2149](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2149)
+[src/types/app-client.ts:2160](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2160)
 
 ___
 
@@ -684,7 +684,7 @@ The current box value as a byte array
 
 #### Defined in
 
-[src/types/app-client.ts:2165](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2165)
+[src/types/app-client.ts:2176](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2176)
 
 ___
 
@@ -709,7 +709,7 @@ The (name, value) pair of the boxes with values as raw byte arrays
 
 #### Defined in
 
-[src/types/app-client.ts:2181](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2181)
+[src/types/app-client.ts:2192](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2192)
 
 ___
 
@@ -735,7 +735,7 @@ The (name, value) pair of the boxes with values as the ABI Value
 
 #### Defined in
 
-[src/types/app-client.ts:2203](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2203)
+[src/types/app-client.ts:2214](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2214)
 
 ___
 
@@ -764,7 +764,7 @@ Returns the arguments for an app call for the given ABI method or raw method spe
 
 #### Defined in
 
-[src/types/app-client.ts:2227](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2227)
+[src/types/app-client.ts:2238](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2238)
 
 ___
 
@@ -782,7 +782,7 @@ The global state
 
 #### Defined in
 
-[src/types/app-client.ts:2106](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2106)
+[src/types/app-client.ts:2117](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2117)
 
 ___
 
@@ -806,7 +806,7 @@ The global state
 
 #### Defined in
 
-[src/types/app-client.ts:2120](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2120)
+[src/types/app-client.ts:2131](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2131)
 
 ___
 
@@ -828,7 +828,7 @@ Import source maps for the app.
 
 #### Defined in
 
-[src/types/app-client.ts:1719](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1719)
+[src/types/app-client.ts:1730](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1730)
 
 ___
 
@@ -856,7 +856,7 @@ Issues a opt_in call to the app.
 
 #### Defined in
 
-[src/types/app-client.ts:1993](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1993)
+[src/types/app-client.ts:2004](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2004)
 
 ___
 
@@ -884,4 +884,4 @@ Updates the smart contract app.
 
 #### Defined in
 
-[src/types/app-client.ts:1914](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1914)
+[src/types/app-client.ts:1925](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1925)

--- a/docs/code/classes/types_app_factory.AppFactory.md
+++ b/docs/code/classes/types_app_factory.AppFactory.md
@@ -666,7 +666,7 @@ if none provided and throws an error if neither provided
 
 #### Defined in
 
-[src/types/app-factory.ts:610](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-factory.ts#L610)
+[src/types/app-factory.ts:609](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-factory.ts#L609)
 
 ___
 
@@ -751,4 +751,4 @@ The smart contract response with an updated return value
 
 #### Defined in
 
-[src/types/app-factory.ts:627](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-factory.ts#L627)
+[src/types/app-factory.ts:626](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-factory.ts#L626)

--- a/docs/code/interfaces/types_app_arc56.Arc56Contract.md
+++ b/docs/code/interfaces/types_app_arc56.Arc56Contract.md
@@ -32,7 +32,7 @@ Describes the entire contract. This interface is an extension of the interface d
 
 • **arcs**: `number`[]
 
-The ARCs used and/or supported by this contract. All contracts implicity support ARC4 and ARC56
+The ARCs used and/or supported by this contract. All contracts implicitly support ARC4 and ARC56
 
 #### Defined in
 
@@ -273,7 +273,7 @@ ___
 
 • `Optional` **templateVariables**: `Object`
 
-A mapping of template variable names as they appear in the teal (not including TMPL_ prefix) to their respecive types and values (if applicable)
+A mapping of template variable names as they appear in the teal (not including TMPL_ prefix) to their respective types and values (if applicable)
 
 #### Index signature
 

--- a/docs/code/interfaces/types_app_arc56.Event.md
+++ b/docs/code/interfaces/types_app_arc56.Event.md
@@ -24,7 +24,7 @@ The arguments of the event, in order
 
 #### Defined in
 
-[src/types/app-arc56.ts:422](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L422)
+[src/types/app-arc56.ts:423](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L423)
 
 ___
 
@@ -36,7 +36,7 @@ Optional, user-friendly description for the event
 
 #### Defined in
 
-[src/types/app-arc56.ts:420](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L420)
+[src/types/app-arc56.ts:421](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L421)
 
 ___
 
@@ -48,4 +48,4 @@ The name of the event
 
 #### Defined in
 
-[src/types/app-arc56.ts:418](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L418)
+[src/types/app-arc56.ts:419](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L419)

--- a/docs/code/interfaces/types_app_arc56.Method.md
+++ b/docs/code/interfaces/types_app_arc56.Method.md
@@ -36,13 +36,13 @@ an action is a combination of call/create and an OnComplete
 
 #### Defined in
 
-[src/types/app-arc56.ts:381](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L381)
+[src/types/app-arc56.ts:382](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L382)
 
 ___
 
 ### args
 
-• **args**: \{ `defaultValue?`: \{ `data`: `string` \| `number` ; `source`: ``"box"`` \| ``"global"`` \| ``"local"`` \| ``"literal"`` ; `type`: `string`  } ; `desc?`: `string` ; `name?`: `string` ; `struct?`: `string` ; `type`: `string`  }[]
+• **args**: \{ `defaultValue?`: \{ `data`: `string` ; `source`: ``"method"`` \| ``"box"`` \| ``"global"`` \| ``"local"`` \| ``"literal"`` ; `type?`: `string`  } ; `desc?`: `string` ; `name?`: `string` ; `struct?`: `string` ; `type`: `string`  }[]
 
 The arguments of the method, in order
 
@@ -72,7 +72,7 @@ ARC-28 events that MAY be emitted by this method
 
 #### Defined in
 
-[src/types/app-arc56.ts:390](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L390)
+[src/types/app-arc56.ts:391](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L391)
 
 ___
 
@@ -96,7 +96,7 @@ If this method does not write anything to the ledger (ARC-22)
 
 #### Defined in
 
-[src/types/app-arc56.ts:388](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L388)
+[src/types/app-arc56.ts:389](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L389)
 
 ___
 
@@ -122,7 +122,7 @@ Information that clients can use when calling the method
 
 #### Defined in
 
-[src/types/app-arc56.ts:392](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L392)
+[src/types/app-arc56.ts:393](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L393)
 
 ___
 
@@ -142,4 +142,4 @@ Information about the method's return value
 
 #### Defined in
 
-[src/types/app-arc56.ts:372](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L372)
+[src/types/app-arc56.ts:373](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L373)

--- a/docs/code/interfaces/types_app_arc56.ProgramSourceInfo.md
+++ b/docs/code/interfaces/types_app_arc56.ProgramSourceInfo.md
@@ -23,7 +23,7 @@ How the program counter offset is calculated
 
 #### Defined in
 
-[src/types/app-arc56.ts:503](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L503)
+[src/types/app-arc56.ts:504](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L504)
 
 ___
 
@@ -35,4 +35,4 @@ The source information for the program
 
 #### Defined in
 
-[src/types/app-arc56.ts:498](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L498)
+[src/types/app-arc56.ts:499](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L499)

--- a/docs/code/interfaces/types_app_arc56.StorageKey.md
+++ b/docs/code/interfaces/types_app_arc56.StorageKey.md
@@ -25,7 +25,7 @@ Description of what this storage key holds
 
 #### Defined in
 
-[src/types/app-arc56.ts:463](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L463)
+[src/types/app-arc56.ts:464](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L464)
 
 ___
 
@@ -37,7 +37,7 @@ The bytes of the key encoded as base64
 
 #### Defined in
 
-[src/types/app-arc56.ts:470](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L470)
+[src/types/app-arc56.ts:471](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L471)
 
 ___
 
@@ -49,7 +49,7 @@ The type of the key
 
 #### Defined in
 
-[src/types/app-arc56.ts:465](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L465)
+[src/types/app-arc56.ts:466](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L466)
 
 ___
 
@@ -61,4 +61,4 @@ The type of the value
 
 #### Defined in
 
-[src/types/app-arc56.ts:468](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L468)
+[src/types/app-arc56.ts:469](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L469)

--- a/docs/code/interfaces/types_app_arc56.StorageMap.md
+++ b/docs/code/interfaces/types_app_arc56.StorageMap.md
@@ -25,7 +25,7 @@ Description of what the key-value pairs in this mapping hold
 
 #### Defined in
 
-[src/types/app-arc56.ts:476](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L476)
+[src/types/app-arc56.ts:477](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L477)
 
 ___
 
@@ -37,7 +37,7 @@ The type of the keys in the map
 
 #### Defined in
 
-[src/types/app-arc56.ts:478](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L478)
+[src/types/app-arc56.ts:479](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L479)
 
 ___
 
@@ -49,7 +49,7 @@ The base64-encoded prefix of the map keys
 
 #### Defined in
 
-[src/types/app-arc56.ts:482](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L482)
+[src/types/app-arc56.ts:483](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L483)
 
 ___
 
@@ -61,4 +61,4 @@ The type of the values in the map
 
 #### Defined in
 
-[src/types/app-arc56.ts:480](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L480)
+[src/types/app-arc56.ts:481](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L481)

--- a/docs/code/interfaces/types_app_arc56.StructField.md
+++ b/docs/code/interfaces/types_app_arc56.StructField.md
@@ -23,7 +23,7 @@ The name of the struct field
 
 #### Defined in
 
-[src/types/app-arc56.ts:455](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L455)
+[src/types/app-arc56.ts:456](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L456)
 
 ___
 
@@ -35,4 +35,4 @@ The type of the struct field's value
 
 #### Defined in
 
-[src/types/app-arc56.ts:457](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L457)
+[src/types/app-arc56.ts:458](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L458)

--- a/docs/code/interfaces/types_app_spec.AppSources.md
+++ b/docs/code/interfaces/types_app_spec.AppSources.md
@@ -23,7 +23,7 @@ The TEAL source of the approval program
 
 #### Defined in
 
-[src/types/app-spec.ts:154](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L154)
+[src/types/app-spec.ts:163](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L163)
 
 ___
 
@@ -35,4 +35,4 @@ The TEAL source of the clear program
 
 #### Defined in
 
-[src/types/app-spec.ts:156](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L156)
+[src/types/app-spec.ts:165](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L165)

--- a/docs/code/interfaces/types_app_spec.AppSpec.md
+++ b/docs/code/interfaces/types_app_spec.AppSpec.md
@@ -27,7 +27,7 @@ The config of all BARE calls (i.e. non ABI calls with no args)
 
 #### Defined in
 
-[src/types/app-spec.ts:145](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L145)
+[src/types/app-spec.ts:154](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L154)
 
 ___
 
@@ -39,7 +39,7 @@ The ABI-0004 contract definition see https://github.com/algorandfoundation/ARCs/
 
 #### Defined in
 
-[src/types/app-spec.ts:139](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L139)
+[src/types/app-spec.ts:148](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L148)
 
 ___
 
@@ -51,7 +51,7 @@ Method call hints
 
 #### Defined in
 
-[src/types/app-spec.ts:135](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L135)
+[src/types/app-spec.ts:144](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L144)
 
 ___
 
@@ -63,7 +63,7 @@ The values that make up the local and global state
 
 #### Defined in
 
-[src/types/app-spec.ts:141](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L141)
+[src/types/app-spec.ts:150](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L150)
 
 ___
 
@@ -75,7 +75,7 @@ The TEAL source
 
 #### Defined in
 
-[src/types/app-spec.ts:137](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L137)
+[src/types/app-spec.ts:146](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L146)
 
 ___
 
@@ -87,4 +87,4 @@ The rolled-up schema allocation values for local and global state
 
 #### Defined in
 
-[src/types/app-spec.ts:143](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L143)
+[src/types/app-spec.ts:152](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L152)

--- a/docs/code/interfaces/types_app_spec.CallConfig.md
+++ b/docs/code/interfaces/types_app_spec.CallConfig.md
@@ -26,7 +26,7 @@ Close out call config
 
 #### Defined in
 
-[src/types/app-spec.ts:174](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L174)
+[src/types/app-spec.ts:183](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L183)
 
 ___
 
@@ -38,7 +38,7 @@ Delete call config
 
 #### Defined in
 
-[src/types/app-spec.ts:178](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L178)
+[src/types/app-spec.ts:187](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L187)
 
 ___
 
@@ -50,7 +50,7 @@ NoOp call config
 
 #### Defined in
 
-[src/types/app-spec.ts:170](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L170)
+[src/types/app-spec.ts:179](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L179)
 
 ___
 
@@ -62,7 +62,7 @@ Opt-in call config
 
 #### Defined in
 
-[src/types/app-spec.ts:172](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L172)
+[src/types/app-spec.ts:181](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L181)
 
 ___
 
@@ -74,4 +74,4 @@ Update call config
 
 #### Defined in
 
-[src/types/app-spec.ts:176](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L176)
+[src/types/app-spec.ts:185](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L185)

--- a/docs/code/interfaces/types_app_spec.DeclaredSchemaValueSpec.md
+++ b/docs/code/interfaces/types_app_spec.DeclaredSchemaValueSpec.md
@@ -25,7 +25,7 @@ A description of the variable
 
 #### Defined in
 
-[src/types/app-spec.ts:259](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L259)
+[src/types/app-spec.ts:268](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L268)
 
 ___
 
@@ -37,7 +37,7 @@ The name of the key
 
 #### Defined in
 
-[src/types/app-spec.ts:257](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L257)
+[src/types/app-spec.ts:266](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L266)
 
 ___
 
@@ -49,7 +49,7 @@ Whether or not the value is set statically (at create time only) or dynamically
 
 #### Defined in
 
-[src/types/app-spec.ts:261](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L261)
+[src/types/app-spec.ts:270](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L270)
 
 ___
 
@@ -61,4 +61,4 @@ The type of value
 
 #### Defined in
 
-[src/types/app-spec.ts:255](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L255)
+[src/types/app-spec.ts:264](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L264)

--- a/docs/code/interfaces/types_app_spec.Hint.md
+++ b/docs/code/interfaces/types_app_spec.Hint.md
@@ -23,7 +23,7 @@ Hint information for a given method call to allow client generation
 
 #### Defined in
 
-[src/types/app-spec.ts:187](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L187)
+[src/types/app-spec.ts:196](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L196)
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 #### Defined in
 
-[src/types/app-spec.ts:186](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L186)
+[src/types/app-spec.ts:195](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L195)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[src/types/app-spec.ts:185](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L185)
+[src/types/app-spec.ts:194](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L194)
 
 ___
 
@@ -55,4 +55,4 @@ Any user-defined struct/tuple types used in the method call, keyed by parameter 
 
 #### Defined in
 
-[src/types/app-spec.ts:184](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L184)
+[src/types/app-spec.ts:193](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L193)

--- a/docs/code/interfaces/types_app_spec.ReservedSchemaValueSpec.md
+++ b/docs/code/interfaces/types_app_spec.ReservedSchemaValueSpec.md
@@ -24,7 +24,7 @@ The description of the reserved storage space
 
 #### Defined in
 
-[src/types/app-spec.ts:269](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L269)
+[src/types/app-spec.ts:278](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L278)
 
 ___
 
@@ -36,7 +36,7 @@ The maximum number of slots to reserve
 
 #### Defined in
 
-[src/types/app-spec.ts:271](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L271)
+[src/types/app-spec.ts:280](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L280)
 
 ___
 
@@ -48,4 +48,4 @@ The type of value
 
 #### Defined in
 
-[src/types/app-spec.ts:267](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L267)
+[src/types/app-spec.ts:276](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L276)

--- a/docs/code/interfaces/types_app_spec.Schema.md
+++ b/docs/code/interfaces/types_app_spec.Schema.md
@@ -23,7 +23,7 @@ Declared storage schema
 
 #### Defined in
 
-[src/types/app-spec.ts:285](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L285)
+[src/types/app-spec.ts:294](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L294)
 
 ___
 
@@ -35,4 +35,4 @@ Reserved storage schema
 
 #### Defined in
 
-[src/types/app-spec.ts:287](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L287)
+[src/types/app-spec.ts:296](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L296)

--- a/docs/code/interfaces/types_app_spec.SchemaSpec.md
+++ b/docs/code/interfaces/types_app_spec.SchemaSpec.md
@@ -23,7 +23,7 @@ The global storage schema
 
 #### Defined in
 
-[src/types/app-spec.ts:279](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L279)
+[src/types/app-spec.ts:288](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L288)
 
 ___
 
@@ -35,4 +35,4 @@ The local storage schema
 
 #### Defined in
 
-[src/types/app-spec.ts:277](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L277)
+[src/types/app-spec.ts:286](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L286)

--- a/docs/code/interfaces/types_app_spec.StateSchemaSpec.md
+++ b/docs/code/interfaces/types_app_spec.StateSchemaSpec.md
@@ -23,7 +23,7 @@ Global storage spec
 
 #### Defined in
 
-[src/types/app-spec.ts:293](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L293)
+[src/types/app-spec.ts:302](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L302)
 
 ___
 
@@ -35,4 +35,4 @@ Local storage spec
 
 #### Defined in
 
-[src/types/app-spec.ts:295](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L295)
+[src/types/app-spec.ts:304](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L304)

--- a/docs/code/interfaces/types_app_spec.Struct.md
+++ b/docs/code/interfaces/types_app_spec.Struct.md
@@ -23,7 +23,7 @@ The elements (in order) that make up the struct/tuple
 
 #### Defined in
 
-[src/types/app-spec.ts:204](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L204)
+[src/types/app-spec.ts:213](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L213)
 
 ___
 
@@ -35,4 +35,4 @@ The name of the type
 
 #### Defined in
 
-[src/types/app-spec.ts:202](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L202)
+[src/types/app-spec.ts:211](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L211)

--- a/docs/code/modules/types_app_arc56.md
+++ b/docs/code/modules/types_app_arc56.md
@@ -66,7 +66,7 @@ An ABI-encoded type
 
 #### Defined in
 
-[src/types/app-arc56.ts:435](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L435)
+[src/types/app-arc56.ts:436](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L436)
 
 ___
 
@@ -78,7 +78,7 @@ Raw byteslice without the length prefixed that is specified in ARC-4
 
 #### Defined in
 
-[src/types/app-arc56.ts:441](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L441)
+[src/types/app-arc56.ts:442](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L442)
 
 ___
 
@@ -90,7 +90,7 @@ A utf-8 string without the length prefix that is specified in ARC-4
 
 #### Defined in
 
-[src/types/app-arc56.ts:444](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L444)
+[src/types/app-arc56.ts:445](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L445)
 
 ___
 
@@ -102,7 +102,7 @@ A native AVM type
 
 #### Defined in
 
-[src/types/app-arc56.ts:450](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L450)
+[src/types/app-arc56.ts:451](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L451)
 
 ___
 
@@ -114,7 +114,7 @@ A 64-bit unsigned integer
 
 #### Defined in
 
-[src/types/app-arc56.ts:447](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L447)
+[src/types/app-arc56.ts:448](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L448)
 
 ___
 
@@ -150,7 +150,7 @@ The name of a defined struct
 
 #### Defined in
 
-[src/types/app-arc56.ts:438](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L438)
+[src/types/app-arc56.ts:439](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-arc56.ts#L439)
 
 ## Functions
 

--- a/docs/code/modules/types_app_spec.md
+++ b/docs/code/modules/types_app_spec.md
@@ -42,7 +42,7 @@ The string name of an ABI type
 
 #### Defined in
 
-[src/types/app-spec.ts:194](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L194)
+[src/types/app-spec.ts:203](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L203)
 
 ___
 
@@ -54,7 +54,7 @@ AVM data type
 
 #### Defined in
 
-[src/types/app-spec.ts:250](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L250)
+[src/types/app-spec.ts:259](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L259)
 
 ___
 
@@ -70,7 +70,7 @@ The various call configs:
 
 #### Defined in
 
-[src/types/app-spec.ts:165](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L165)
+[src/types/app-spec.ts:174](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L174)
 
 ___
 
@@ -82,7 +82,7 @@ Defines a strategy for obtaining a default value for a given ABI arg.
 
 #### Defined in
 
-[src/types/app-spec.ts:210](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L210)
+[src/types/app-spec.ts:219](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L219)
 
 ___
 
@@ -94,7 +94,7 @@ The name of a field
 
 #### Defined in
 
-[src/types/app-spec.ts:191](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L191)
+[src/types/app-spec.ts:200](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L200)
 
 ___
 
@@ -106,7 +106,7 @@ A lookup of encoded method call spec to hint
 
 #### Defined in
 
-[src/types/app-spec.ts:149](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L149)
+[src/types/app-spec.ts:158](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L158)
 
 ___
 
@@ -125,7 +125,7 @@ Schema spec summary for global or local storage
 
 #### Defined in
 
-[src/types/app-spec.ts:299](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L299)
+[src/types/app-spec.ts:308](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L308)
 
 ___
 
@@ -137,7 +137,7 @@ The elements of the struct/tuple: `FieldName`, `ABIType`
 
 #### Defined in
 
-[src/types/app-spec.ts:197](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L197)
+[src/types/app-spec.ts:206](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts#L206)
 
 ## Functions
 

--- a/src/types/app-arc56.ts
+++ b/src/types/app-arc56.ts
@@ -355,17 +355,18 @@ export interface Method {
     desc?: string
     /** The default value that clients should use. */
     defaultValue?: {
-      /** Base64 encoded bytes or uint64 */
-      data: string | number
+      /** Base64 encoded bytes, base64 ARC4 encoded uint64, or UTF-8 method selector */
+      data: string
       /** How the data is encoded. This is the encoding for the data provided here, not the arg type */
-      type: ABIType | AVMType
+      type?: ABIType | AVMType
       /** Where the default value is coming from
        * - box: The data key signifies the box key to read the value from
        * - global: The data key signifies the global state key to read the value from
        * - local: The data key signifies the local state key to read the value from (for the sender)
        * - literal: the value is a literal and should be passed directly as the argument
+       * - method: The utf8 signature of the method in this contract to call to get the default value. If the method has arguments, they all must have default values. The method **MUST** be readonly so simulate can be used to get the default value
        */
-      source: 'box' | 'global' | 'local' | 'literal'
+      source: 'box' | 'global' | 'local' | 'literal' | 'method'
     }
   }>
   /** Information about the method's return value */

--- a/src/types/app-arc56.ts
+++ b/src/types/app-arc56.ts
@@ -229,7 +229,7 @@ export function getArc56ReturnValue<TReturn extends Uint8Array | algosdk.ABIValu
 
 /** Describes the entire contract. This interface is an extension of the interface described in ARC-4 */
 export interface Arc56Contract {
-  /** The ARCs used and/or supported by this contract. All contracts implicity support ARC4 and ARC56 */
+  /** The ARCs used and/or supported by this contract. All contracts implicitly support ARC4 and ARC56 */
   arcs: number[]
   /** A user-friendly name for the contract */
   name: string
@@ -319,7 +319,7 @@ export interface Arc56Contract {
   }
   /** ARC-28 events that MAY be emitted by this contract */
   events?: Array<Event>
-  /** A mapping of template variable names as they appear in the teal (not including TMPL_ prefix) to their respecive types and values (if applicable) */
+  /** A mapping of template variable names as they appear in the teal (not including TMPL_ prefix) to their respective types and values (if applicable) */
   templateVariables?: {
     [name: string]: {
       /** The type of the template variable */
@@ -421,7 +421,7 @@ export interface Event {
   desc?: string
   /** The arguments of the event, in order */
   args: Array<{
-    /** The type of the argument. The `struct` field should also be checked to determine if this return value is a struct. */
+    /** The type of the argument. The `struct` field should also be checked to determine if this arg is a struct. */
     type: ABIType
     /** Optional, user-friendly name for the argument */
     name?: string

--- a/src/types/app-client.ts
+++ b/src/types/app-client.ts
@@ -1064,7 +1064,7 @@ export class AppClient {
                 sender,
               })
 
-              if (!result.return) {
+              if (result.return === undefined) {
                 throw new Error('Default value method call did not return a value')
               }
               if (typeof result.return === 'object' && !(result.return instanceof Uint8Array) && !Array.isArray(result.return)) {

--- a/src/types/app-client.ts
+++ b/src/types/app-client.ts
@@ -541,6 +541,12 @@ export class AppClient {
     }
   }
 
+  /**
+   * Clone this app client with different params
+   *
+   * @param params The params to use for the the cloned app client. Omit a param to keep the original value. Set a param to override the original value. Setting to undefined will clear the original value.
+   * @returns A new app client with the altered params
+   */
   public clone(params: CloneAppClientParams) {
     return new AppClient({
       appId: this._appId,
@@ -1051,16 +1057,15 @@ export class AppClient {
                 m.method.args[i].defaultValue?.type ?? m.method.args[i].type,
                 this._appSpec.structs,
               ) as ABIValue
-            // todo: When ARC-56 supports ABI calls as default args
-            // case 'abi': {
-            //   const method = this.getABIMethod(defaultValue.data as string)
-            //   const result = await this.send.call({
-            //     method: defaultValue.data as string,
-            //     methodArgs: method.args.map(() => undefined),
-            //     sender,
-            //   })
-            //   return result.return!
-            // }
+            case 'abi': {
+              const method = this.getABIMethod(defaultValue.data as string)
+              const result = await this.send.call({
+                method: defaultValue.data as string,
+                methodArgs: method.args.map(() => undefined),
+                sender,
+              })
+              return result.return!
+            }
             case 'local':
             case 'global': {
               const state = defaultValue.source === 'global' ? await this.getGlobalState() : await this.getLocalState(sender)

--- a/src/types/app-factory-and-client.spec.ts
+++ b/src/types/app-factory-and-client.spec.ts
@@ -635,8 +635,7 @@ describe('ARC32: app-factory-and-app-client', () => {
       await testAbiWithDefaultArgMethod('default_value(string)string', 'defined value', 'defined value', 'default value')
     })
 
-    // todo: Waiting for ABI support in ARC-56
-    test.skip('from abi method', async () => {
+    test('from abi method', async () => {
       await testAbiWithDefaultArgMethod('default_value_from_abi(string)string', 'defined value', 'ABI, defined value', 'ABI, default value')
     })
 

--- a/src/types/app-factory.ts
+++ b/src/types/app-factory.ts
@@ -595,7 +595,6 @@ export class AppFactory {
       if (defaultValue) {
         switch (defaultValue.source) {
           case 'literal':
-            if (typeof defaultValue.data === 'number') return defaultValue.data
             return getABIDecodedValue(Buffer.from(defaultValue.data, 'base64'), m.method.args[i].type, this._appSpec.structs) as ABIValue
           default:
             throw new Error(`Can't provide default value for ${defaultValue.source} for a contract creation call`)

--- a/src/types/app-spec.ts
+++ b/src/types/app-spec.ts
@@ -33,11 +33,20 @@ export function arc32ToArc56(appSpec: AppSpec): Arc56Contract {
     type: string,
     defaultArg: DefaultArgument | undefined,
   ): Arc56Contract['methods'][0]['args'][0]['defaultValue'] => {
-    if (!defaultArg || defaultArg.source === 'abi-method') return undefined
+    if (!defaultArg) return undefined
+
+    if (defaultArg.source === 'abi-method') {
+      return {
+        source: 'method',
+        data: defaultArg.data.name,
+      }
+    }
 
     return {
       source: defaultArg.source === 'constant' ? 'literal' : defaultArg.source === 'global-state' ? 'global' : 'local',
-      data: typeof defaultArg.data === 'string' ? Buffer.from(defaultArg.data).toString('base64') : defaultArg.data,
+      data: Buffer.from(
+        typeof defaultArg.data === 'number' ? algosdk.ABIType.from('uint64').encode(defaultArg.data) : defaultArg.data,
+      ).toString('base64'),
       type: type === 'string' ? 'AVMString' : type,
     }
   }


### PR DESCRIPTION
- Add support for ABI method calls as default values
- Align the ARC56 types to the latest spec
- Add some tsdocs to the newly added clone method