### PR TITLE
fix: prevent base64 in teal from being stripped as a comment

### DIFF
--- a/docs/code/classes/types_app_manager.AppManager.md
+++ b/docs/code/classes/types_app_manager.AppManager.md
@@ -524,4 +524,4 @@ The TEAL without comments
 
 #### Defined in
 
-[src/types/app-manager.ts:462](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-manager.ts#L462)
+[src/types/app-manager.ts:463](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-manager.ts#L463)

--- a/docs/code/interfaces/types_app_arc56.Arc56Contract.md
+++ b/docs/code/interfaces/types_app_arc56.Arc56Contract.md
@@ -157,7 +157,7 @@ Optional object listing the contract instances across different networks.
 The key is the base64 genesis hash of the network, and the value contains
 information about the deployed contract in the network indicated by the
 key. A key containing the human-readable name of the network MAY be
-included, but the corresponding genesis hash key MUST also be define
+included, but the corresponding genesis hash key MUST also be defined
 
 #### Index signature
 
@@ -257,7 +257,7 @@ ___
 
 • **structs**: `Object`
 
-Named structs use by the application. Each struct field appears in the same order as ABI encoding.
+Named structs used by the application. Each struct field appears in the same order as ABI encoding.
 
 #### Index signature
 
@@ -273,7 +273,7 @@ ___
 
 • `Optional` **templateVariables**: `Object`
 
-A mapping of template variable names as they appear in the teal (not including TMPL_ prefix) to their respective types and values (if applicable)
+A mapping of template variable names as they appear in the TEAL (not including TMPL_ prefix) to their respective types and values (if applicable)
 
 #### Index signature
 

--- a/src/app-deploy.ts
+++ b/src/app-deploy.ts
@@ -330,15 +330,5 @@ export async function performTemplateSubstitutionAndCompile(
  * @returns The TEAL without comments
  */
 export function stripTealComments(tealCode: string) {
-  // find // outside quotes, i.e. won't pick up "//not a comment"
-  const regex = /\/\/(?=([^"\\]*(\\.|"([^"\\]*\\.)*[^"\\]*"))*[^"]*$)/
-
-  tealCode = tealCode
-    .split('\n')
-    .map((tealCodeLine) => {
-      return tealCodeLine.split(regex)[0].trim()
-    })
-    .join('\n')
-
-  return tealCode
+  return AppManager.stripTealComments(tealCode)
 }

--- a/src/types/app-arc56.ts
+++ b/src/types/app-arc56.ts
@@ -240,7 +240,7 @@ export interface Arc56Contract {
    * The key is the base64 genesis hash of the network, and the value contains
    * information about the deployed contract in the network indicated by the
    * key. A key containing the human-readable name of the network MAY be
-   * included, but the corresponding genesis hash key MUST also be define
+   * included, but the corresponding genesis hash key MUST also be defined
    */
   networks?: {
     [network: string]: {
@@ -248,7 +248,7 @@ export interface Arc56Contract {
       appID: number
     }
   }
-  /** Named structs use by the application. Each struct field appears in the same order as ABI encoding. */
+  /** Named structs used by the application. Each struct field appears in the same order as ABI encoding. */
   structs: { [structName: StructName]: StructField[] }
   /** All of the methods that the contract implements */
   methods: Method[]
@@ -319,12 +319,12 @@ export interface Arc56Contract {
   }
   /** ARC-28 events that MAY be emitted by this contract */
   events?: Array<Event>
-  /** A mapping of template variable names as they appear in the teal (not including TMPL_ prefix) to their respective types and values (if applicable) */
+  /** A mapping of template variable names as they appear in the TEAL (not including TMPL_ prefix) to their respective types and values (if applicable) */
   templateVariables?: {
     [name: string]: {
       /** The type of the template variable */
       type: ABIType | AVMType | StructName
-      /** If given, the the base64 encoded value used for the given app/program */
+      /** If given, the base64 encoded value used for the given app/program */
       value?: string
     }
   }


### PR DESCRIPTION
As part of this PR we've ported over the utils-py code, as it handles a few more scenarios with regards to comment stripping and token replacement and more closely follows ARC47.