### PR TITLE
fix: update NPM readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The goal of this library is to provide intuitive, productive utility functions t
 
 Note: If you prefer Python there's an equivalent [Python utility library](https://github.com/algorandfoundation/algokit-utils-py).
 
-[Install](#install) | [Documentation](docs/README.md)
+[Install](#install) | [Documentation](./docs/README.md)
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build:1-compile": "rollup -c --configPlugin typescript",
     "build:3-copy-pkg-json": "npx --yes @makerx/ts-toolkit@latest copy-package-json --custom-sections module main type types exports",
     "build:4-copy-readme": "cpy README.md LICENSE dist",
+    "build:5-fix-readme-links": "replace-in-files --string '(./' --replacement '(https://github.com/algorandfoundation/algokit-utils-ts/blob/main/' dist/README.md",
     "test": "vitest run --coverage --passWithNoTests",
     "test:watch": "vitest watch --coverage --passWithNoTests",
     "lint": "eslint ./src/ --ext .ts",


### PR DESCRIPTION
Convert relative links within the package readme to absolute, so that when the readme is displayed in NPM, the links are valid.

Note: This will require a release so that the NPM package readme is updated.