### PR TITLE
feat: logic error logging

### DIFF
--- a/src/transaction/transaction.spec.ts
+++ b/src/transaction/transaction.spec.ts
@@ -441,9 +441,13 @@ describe('Resource Packer: meta', () => {
   })
 
   test('error during simulate', async () => {
-    await expect(externalClient.send.call({ method: 'error' })).rejects.toThrow(
-      'Error during resource population simulation in transaction 0',
-    )
+    try {
+      await externalClient.send.call({ method: 'error' })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      expect(e.stack).toMatch(`err <--- Error`)
+      expect(e.message).toMatch('Error during resource population simulation in transaction 0')
+    }
   })
 
   test('box with txn arg', async () => {

--- a/src/types/app-client.ts
+++ b/src/types/app-client.ts
@@ -1429,7 +1429,16 @@ export class AppClient {
     try {
       return await call()
     } catch (e) {
-      throw await this.exposeLogicError(e as Error)
+      const logicError = await this.exposeLogicError(e as Error)
+      if (logicError instanceof LogicError) {
+        let currentLine = logicError.teal_line - logicError.lines - 1
+        const stackWithLines = logicError.stack
+          ?.split('\n')
+          .map((line) => `${(currentLine += 1)}: ${line}`)
+          .join('\n')
+        Config.logger.error(`${logicError.message}\n\n${stackWithLines}`)
+      }
+      throw logicError
     }
   }
 


### PR DESCRIPTION
## Proposed Changes

- Logs logic error stack to via `Config.logger.error`

This is useful in test environments because some frameworks (jest, vitest) cut off errors. This means the framework will only show the unparsed logic error with the PC and opcodes. This PR adds explicit logging with the stack from the LogicError to ensure the developer gets feedback on where the error occurs