### PR TITLE
fix: waitForIndexer waiting for transactions that failed

### DIFF
--- a/docs/code/classes/testing.TransactionLogger.md
+++ b/docs/code/classes/testing.TransactionLogger.md
@@ -130,14 +130,15 @@ ___
 
 ### waitForIndexer
 
-▸ **waitForIndexer**(`indexer`): `Promise`\<`void`\>
+▸ **waitForIndexer**(`algod`, `indexer`): `Promise`\<`void`\>
 
-Wait until all logged transactions IDs appear in the given `Indexer`.
+Wait until indexer has the last round from algod.
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
+| `algod` | `AlgodClient` |
 | `indexer` | `IndexerClient` |
 
 #### Returns

--- a/src/testing/fixtures/algorand-fixture.ts
+++ b/src/testing/fixtures/algorand-fixture.ts
@@ -111,7 +111,7 @@ export function algorandFixture(fixtureConfig?: AlgorandFixtureConfig, config?: 
         return account
       },
       transactionLogger: transactionLogger,
-      waitForIndexer: () => transactionLogger.waitForIndexer(indexer),
+      waitForIndexer: () => transactionLogger.waitForIndexer(algod, indexer),
       waitForIndexerTransaction: (transactionId: string) => runWhenIndexerCaughtUp(() => indexer.lookupTransactionByID(transactionId).do()),
     }
   }

--- a/src/testing/transaction-logger.ts
+++ b/src/testing/transaction-logger.ts
@@ -49,9 +49,10 @@ export class TransactionLogger {
     return new Proxy<Algodv2>(algod, new TransactionLoggingAlgodv2ProxyHandler(this))
   }
 
-  /** Wait until all logged transactions IDs appear in the given `Indexer`. */
-  async waitForIndexer(indexer: Indexer) {
-    await Promise.all(this._sentTransactionIds.map((txnId) => runWhenIndexerCaughtUp(() => indexer.lookupTransactionByID(txnId).do())))
+  /** Wait until indexer has the last round from algod. */
+  async waitForIndexer(algod: Algodv2, indexer: Indexer) {
+    const round = (await algod.status().do()).lastRound
+    await runWhenIndexerCaughtUp(() => indexer.lookupBlock(round).do())
   }
 }
 


### PR DESCRIPTION
## Proposed Changes

- Fixes the bug that was uncovered in #356 (and probably has surfaced before)

A few questions:

1. Is there a reason why txids were used instead of round? Is there a concern a block will be in indexer but not a txn?
2. On cursory glance, this seems to be the only use-case for the transaction logger. Is there another usecase that I am missing or can we stop using this class and mark it for deprecation? (assuming it's not commonly used externally)
