### PR TITLE
feat: add heartbeat data to indexer types

### DIFF
--- a/docs/code/enums/types_indexer.AccountStatus.md
+++ b/docs/code/enums/types_indexer.AccountStatus.md
@@ -24,7 +24,7 @@ Indicates that the associated account is neither a delegator nor a delegate
 
 #### Defined in
 
-[src/types/indexer.ts:806](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L806)
+[src/types/indexer.ts:854](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L854)
 
 ___
 
@@ -36,7 +36,7 @@ Indicates that the associated account is delegated
 
 #### Defined in
 
-[src/types/indexer.ts:802](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L802)
+[src/types/indexer.ts:850](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L850)
 
 ___
 
@@ -48,4 +48,4 @@ Indicates that the associated account used as part of the delegation pool
 
 #### Defined in
 
-[src/types/indexer.ts:804](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L804)
+[src/types/indexer.ts:852](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L852)

--- a/docs/code/enums/types_indexer.ApplicationOnComplete.md
+++ b/docs/code/enums/types_indexer.ApplicationOnComplete.md
@@ -25,7 +25,7 @@ Defines the what additional actions occur with the transaction https://developer
 
 #### Defined in
 
-[src/types/indexer.ts:709](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L709)
+[src/types/indexer.ts:757](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L757)
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:708](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L708)
+[src/types/indexer.ts:756](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L756)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:711](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L711)
+[src/types/indexer.ts:759](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L759)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:706](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L706)
+[src/types/indexer.ts:754](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L754)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:707](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L707)
+[src/types/indexer.ts:755](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L755)
 
 ___
 
@@ -75,4 +75,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:710](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L710)
+[src/types/indexer.ts:758](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L758)

--- a/docs/code/enums/types_indexer.SignatureType.md
+++ b/docs/code/enums/types_indexer.SignatureType.md
@@ -24,7 +24,7 @@ Logic signature
 
 #### Defined in
 
-[src/types/indexer.ts:796](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L796)
+[src/types/indexer.ts:844](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L844)
 
 ___
 
@@ -36,7 +36,7 @@ Multisig
 
 #### Defined in
 
-[src/types/indexer.ts:794](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L794)
+[src/types/indexer.ts:842](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L842)
 
 ___
 
@@ -48,4 +48,4 @@ Normal signature
 
 #### Defined in
 
-[src/types/indexer.ts:792](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L792)
+[src/types/indexer.ts:840](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L840)

--- a/docs/code/interfaces/types_indexer.AccountParticipation.md
+++ b/docs/code/interfaces/types_indexer.AccountParticipation.md
@@ -29,7 +29,7 @@ AccountParticipation describes the parameters used by this account in consensus 
 
 #### Defined in
 
-[src/types/indexer.ts:815](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L815)
+[src/types/indexer.ts:863](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L863)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:820](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L820)
+[src/types/indexer.ts:868](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L868)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:822](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L822)
+[src/types/indexer.ts:870](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L870)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:824](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L824)
+[src/types/indexer.ts:872](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L872)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:826](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L826)
+[src/types/indexer.ts:874](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L874)
 
 ___
 
@@ -93,4 +93,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:831](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L831)
+[src/types/indexer.ts:879](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L879)

--- a/docs/code/interfaces/types_indexer.AccountResult.md
+++ b/docs/code/interfaces/types_indexer.AccountResult.md
@@ -53,7 +53,7 @@ the account public key
 
 #### Defined in
 
-[src/types/indexer.ts:212](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L212)
+[src/types/indexer.ts:214](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L214)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:214](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L214)
+[src/types/indexer.ts:216](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L216)
 
 ___
 
@@ -77,7 +77,7 @@ specifies the amount of µAlgo in the account, without the pending rewards.
 
 #### Defined in
 
-[src/types/indexer.ts:216](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L216)
+[src/types/indexer.ts:218](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L218)
 
 ___
 
@@ -91,7 +91,7 @@ Note the raw object uses map[int] -> AppLocalState for this type.
 
 #### Defined in
 
-[src/types/indexer.ts:221](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L221)
+[src/types/indexer.ts:223](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L223)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:223](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L223)
+[src/types/indexer.ts:225](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L225)
 
 ___
 
@@ -117,7 +117,7 @@ Note: the raw account uses StateSchema for this type.
 
 #### Defined in
 
-[src/types/indexer.ts:228](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L228)
+[src/types/indexer.ts:230](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L230)
 
 ___
 
@@ -131,7 +131,7 @@ Note the raw object uses map[int] -> AssetHolding for this type.
 
 #### Defined in
 
-[src/types/indexer.ts:233](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L233)
+[src/types/indexer.ts:235](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L235)
 
 ___
 
@@ -147,7 +147,7 @@ This field can be updated in any transaction by setting the RekeyTo field.
 
 #### Defined in
 
-[src/types/indexer.ts:240](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L240)
+[src/types/indexer.ts:242](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L242)
 
 ___
 
@@ -159,7 +159,7 @@ Round during which this account was most recently closed.
 
 #### Defined in
 
-[src/types/indexer.ts:242](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L242)
+[src/types/indexer.ts:244](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L244)
 
 ___
 
@@ -173,7 +173,7 @@ Note: the raw account uses map[int] -> AppParams for this type.
 
 #### Defined in
 
-[src/types/indexer.ts:247](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L247)
+[src/types/indexer.ts:249](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L249)
 
 ___
 
@@ -187,7 +187,7 @@ Note: the raw account uses map[int] -> Asset for this type.
 
 #### Defined in
 
-[src/types/indexer.ts:252](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L252)
+[src/types/indexer.ts:254](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L254)
 
 ___
 
@@ -199,7 +199,7 @@ Round during which this account first appeared in a transaction.
 
 #### Defined in
 
-[src/types/indexer.ts:254](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L254)
+[src/types/indexer.ts:256](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L256)
 
 ___
 
@@ -211,7 +211,7 @@ Whether or not this account is currently closed.
 
 #### Defined in
 
-[src/types/indexer.ts:256](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L256)
+[src/types/indexer.ts:258](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L258)
 
 ___
 
@@ -223,7 +223,7 @@ If participating in consensus, the parameters used by this account in the consen
 
 #### Defined in
 
-[src/types/indexer.ts:258](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L258)
+[src/types/indexer.ts:260](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L260)
 
 ___
 
@@ -235,7 +235,7 @@ amount of µAlgo of pending rewards in this account.
 
 #### Defined in
 
-[src/types/indexer.ts:260](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L260)
+[src/types/indexer.ts:262](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L262)
 
 ___
 
@@ -247,7 +247,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:262](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L262)
+[src/types/indexer.ts:264](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L264)
 
 ___
 
@@ -259,7 +259,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:264](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L264)
+[src/types/indexer.ts:266](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L266)
 
 ___
 
@@ -271,7 +271,7 @@ The round for which this information is relevant.
 
 #### Defined in
 
-[src/types/indexer.ts:266](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L266)
+[src/types/indexer.ts:268](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L268)
 
 ___
 
@@ -283,7 +283,7 @@ Indicates what type of signature is used by this account
 
 #### Defined in
 
-[src/types/indexer.ts:268](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L268)
+[src/types/indexer.ts:270](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L270)
 
 ___
 
@@ -295,7 +295,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:270](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L270)
+[src/types/indexer.ts:272](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L272)
 
 ___
 
@@ -307,7 +307,7 @@ The count of all applications that have been opted in, equivalent to the count o
 
 #### Defined in
 
-[src/types/indexer.ts:272](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L272)
+[src/types/indexer.ts:274](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L274)
 
 ___
 
@@ -319,7 +319,7 @@ The count of all assets that have been opted in, equivalent to the count of Asse
 
 #### Defined in
 
-[src/types/indexer.ts:274](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L274)
+[src/types/indexer.ts:276](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L276)
 
 ___
 
@@ -331,7 +331,7 @@ For app-accounts only. The total number of bytes allocated for the keys and valu
 
 #### Defined in
 
-[src/types/indexer.ts:276](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L276)
+[src/types/indexer.ts:278](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L278)
 
 ___
 
@@ -343,7 +343,7 @@ For app-accounts only. The total number of boxes which belong to the associated 
 
 #### Defined in
 
-[src/types/indexer.ts:278](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L278)
+[src/types/indexer.ts:280](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L280)
 
 ___
 
@@ -355,7 +355,7 @@ The count of all apps (AppParams objects) created by this account.
 
 #### Defined in
 
-[src/types/indexer.ts:280](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L280)
+[src/types/indexer.ts:282](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L282)
 
 ___
 
@@ -367,4 +367,4 @@ The count of all assets (AssetParams objects) created by this account.
 
 #### Defined in
 
-[src/types/indexer.ts:282](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L282)
+[src/types/indexer.ts:284](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L284)

--- a/docs/code/interfaces/types_indexer.AccountStateDelta.md
+++ b/docs/code/interfaces/types_indexer.AccountStateDelta.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/types/indexer.ts:640](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L640)
+[src/types/indexer.ts:688](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L688)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:641](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L641)
+[src/types/indexer.ts:689](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L689)

--- a/docs/code/interfaces/types_indexer.AppLocalState.md
+++ b/docs/code/interfaces/types_indexer.AppLocalState.md
@@ -27,7 +27,7 @@ Round when account closed out of the application.
 
 #### Defined in
 
-[src/types/indexer.ts:837](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L837)
+[src/types/indexer.ts:885](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L885)
 
 ___
 
@@ -39,7 +39,7 @@ Whether or not the application local state is currently deleted from its account
 
 #### Defined in
 
-[src/types/indexer.ts:839](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L839)
+[src/types/indexer.ts:887](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L887)
 
 ___
 
@@ -51,7 +51,7 @@ The application which this local state is for.
 
 #### Defined in
 
-[src/types/indexer.ts:841](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L841)
+[src/types/indexer.ts:889](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L889)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:843](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L843)
+[src/types/indexer.ts:891](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L891)
 
 ___
 
@@ -75,7 +75,7 @@ Round when the account opted into the application.
 
 #### Defined in
 
-[src/types/indexer.ts:845](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L845)
+[src/types/indexer.ts:893](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L893)
 
 ___
 
@@ -87,4 +87,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:847](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L847)
+[src/types/indexer.ts:895](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L895)

--- a/docs/code/interfaces/types_indexer.ApplicationParams.md
+++ b/docs/code/interfaces/types_indexer.ApplicationParams.md
@@ -34,7 +34,7 @@ Approval programs may reject the transaction.
 
 #### Defined in
 
-[src/types/indexer.ts:669](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L669)
+[src/types/indexer.ts:717](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L717)
 
 ___
 
@@ -52,7 +52,7 @@ Clear state programs cannot reject the transaction.
 
 #### Defined in
 
-[src/types/indexer.ts:679](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L679)
+[src/types/indexer.ts:727](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L727)
 
 ___
 
@@ -64,7 +64,7 @@ The address that created this application. This is the address where the paramet
 
 #### Defined in
 
-[src/types/indexer.ts:659](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L659)
+[src/types/indexer.ts:707](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L707)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:681](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L681)
+[src/types/indexer.ts:729](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L729)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:683](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L683)
+[src/types/indexer.ts:731](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L731)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:685](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L685)
+[src/types/indexer.ts:733](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L733)
 
 ___
 
@@ -112,4 +112,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:687](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L687)
+[src/types/indexer.ts:735](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L735)

--- a/docs/code/interfaces/types_indexer.ApplicationResult.md
+++ b/docs/code/interfaces/types_indexer.ApplicationResult.md
@@ -24,7 +24,7 @@ The result of looking up an application
 
 #### Defined in
 
-[src/types/indexer.ts:567](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L567)
+[src/types/indexer.ts:615](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L615)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:568](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L568)
+[src/types/indexer.ts:616](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L616)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:569](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L569)
+[src/types/indexer.ts:617](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L617)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:565](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L565)
+[src/types/indexer.ts:613](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L613)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:566](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L566)
+[src/types/indexer.ts:614](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L614)

--- a/docs/code/interfaces/types_indexer.ApplicationTransactionResult.md
+++ b/docs/code/interfaces/types_indexer.ApplicationTransactionResult.md
@@ -38,7 +38,7 @@ Fields for an application transaction https://developer.algorand.org/docs/rest-a
 
 #### Defined in
 
-[src/types/indexer.ts:469](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L469)
+[src/types/indexer.ts:517](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L517)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:471](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L471)
+[src/types/indexer.ts:519](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L519)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:473](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L473)
+[src/types/indexer.ts:521](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L521)
 
 ___
 
@@ -84,7 +84,7 @@ Omit.approval-program
 
 #### Defined in
 
-[src/types/indexer.ts:669](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L669)
+[src/types/indexer.ts:717](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L717)
 
 ___
 
@@ -106,7 +106,7 @@ Omit.clear-state-program
 
 #### Defined in
 
-[src/types/indexer.ts:679](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L679)
+[src/types/indexer.ts:727](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L727)
 
 ___
 
@@ -122,7 +122,7 @@ Omit.extra-program-pages
 
 #### Defined in
 
-[src/types/indexer.ts:681](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L681)
+[src/types/indexer.ts:729](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L729)
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:475](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L475)
+[src/types/indexer.ts:523](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L523)
 
 ___
 
@@ -146,7 +146,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:477](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L477)
+[src/types/indexer.ts:525](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L525)
 
 ___
 
@@ -162,7 +162,7 @@ Omit.global-state-schema
 
 #### Defined in
 
-[src/types/indexer.ts:685](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L685)
+[src/types/indexer.ts:733](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L733)
 
 ___
 
@@ -178,7 +178,7 @@ Omit.local-state-schema
 
 #### Defined in
 
-[src/types/indexer.ts:687](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L687)
+[src/types/indexer.ts:735](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L735)
 
 ___
 
@@ -190,4 +190,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:479](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L479)
+[src/types/indexer.ts:527](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L527)

--- a/docs/code/interfaces/types_indexer.AssetConfigTransactionResult.md
+++ b/docs/code/interfaces/types_indexer.AssetConfigTransactionResult.md
@@ -26,7 +26,7 @@ A zero value for asset-id indicates asset creation. A zero value for the params 
 
 #### Defined in
 
-[src/types/indexer.ts:489](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L489)
+[src/types/indexer.ts:537](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L537)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:491](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L491)
+[src/types/indexer.ts:539](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L539)

--- a/docs/code/interfaces/types_indexer.AssetFreezeTransactionResult.md
+++ b/docs/code/interfaces/types_indexer.AssetFreezeTransactionResult.md
@@ -24,7 +24,7 @@ Fields for an asset freeze transaction. https://developer.algorand.org/docs/rest
 
 #### Defined in
 
-[src/types/indexer.ts:497](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L497)
+[src/types/indexer.ts:545](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L545)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:499](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L499)
+[src/types/indexer.ts:547](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L547)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:501](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L501)
+[src/types/indexer.ts:549](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L549)

--- a/docs/code/interfaces/types_indexer.AssetHolding.md
+++ b/docs/code/interfaces/types_indexer.AssetHolding.md
@@ -27,7 +27,7 @@ Describes an asset held by an account. https://developer.algorand.org/docs/rest-
 
 #### Defined in
 
-[src/types/indexer.ts:855](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L855)
+[src/types/indexer.ts:903](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L903)
 
 ___
 
@@ -39,7 +39,7 @@ Asset ID of the holding.
 
 #### Defined in
 
-[src/types/indexer.ts:859](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L859)
+[src/types/indexer.ts:907](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L907)
 
 ___
 
@@ -51,7 +51,7 @@ Whether or not the asset holding is currently deleted from its account.
 
 #### Defined in
 
-[src/types/indexer.ts:861](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L861)
+[src/types/indexer.ts:909](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L909)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:865](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L865)
+[src/types/indexer.ts:913](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L913)
 
 ___
 
@@ -75,7 +75,7 @@ Round during which the account opted into this asset holding.
 
 #### Defined in
 
-[src/types/indexer.ts:867](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L867)
+[src/types/indexer.ts:915](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L915)
 
 ___
 
@@ -87,4 +87,4 @@ Round during which the account opted out of this asset holding.
 
 #### Defined in
 
-[src/types/indexer.ts:869](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L869)
+[src/types/indexer.ts:917](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L917)

--- a/docs/code/interfaces/types_indexer.AssetParams.md
+++ b/docs/code/interfaces/types_indexer.AssetParams.md
@@ -37,7 +37,7 @@ clawback is not permitted.
 
 #### Defined in
 
-[src/types/indexer.ts:737](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L737)
+[src/types/indexer.ts:785](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L785)
 
 ___
 
@@ -51,7 +51,7 @@ be sent in the worst case.
 
 #### Defined in
 
-[src/types/indexer.ts:721](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L721)
+[src/types/indexer.ts:769](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L769)
 
 ___
 
@@ -66,7 +66,7 @@ must be between 0 and 19 (inclusive).
 
 #### Defined in
 
-[src/types/indexer.ts:728](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L728)
+[src/types/indexer.ts:776](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L776)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:741](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L741)
+[src/types/indexer.ts:789](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L789)
 
 ___
 
@@ -91,7 +91,7 @@ is not permitted.
 
 #### Defined in
 
-[src/types/indexer.ts:746](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L746)
+[src/types/indexer.ts:794](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L794)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:750](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L750)
+[src/types/indexer.ts:798](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L798)
 
 ___
 
@@ -116,7 +116,7 @@ metadata is up to the application.
 
 #### Defined in
 
-[src/types/indexer.ts:755](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L755)
+[src/types/indexer.ts:803](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L803)
 
 ___
 
@@ -129,7 +129,7 @@ asset name is composed of printable utf-8 characters.
 
 #### Defined in
 
-[src/types/indexer.ts:760](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L760)
+[src/types/indexer.ts:808](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L808)
 
 ___
 
@@ -141,7 +141,7 @@ Base64 encoded name of this asset, as supplied by the creator.
 
 #### Defined in
 
-[src/types/indexer.ts:764](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L764)
+[src/types/indexer.ts:812](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L812)
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:768](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L768)
+[src/types/indexer.ts:816](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L816)
 
 ___
 
@@ -165,7 +165,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:732](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L732)
+[src/types/indexer.ts:780](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L780)
 
 ___
 
@@ -178,7 +178,7 @@ when the name of a unit of this asset is composed of printable utf-8 characters.
 
 #### Defined in
 
-[src/types/indexer.ts:773](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L773)
+[src/types/indexer.ts:821](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L821)
 
 ___
 
@@ -190,7 +190,7 @@ Base64 encoded name of a unit of this asset, as supplied by the creator.
 
 #### Defined in
 
-[src/types/indexer.ts:777](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L777)
+[src/types/indexer.ts:825](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L825)
 
 ___
 
@@ -203,7 +203,7 @@ when the URL is composed of printable utf-8 characters.
 
 #### Defined in
 
-[src/types/indexer.ts:782](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L782)
+[src/types/indexer.ts:830](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L830)
 
 ___
 
@@ -215,4 +215,4 @@ Base64 encoded URL where more information about the asset can be retrieved.
 
 #### Defined in
 
-[src/types/indexer.ts:786](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L786)
+[src/types/indexer.ts:834](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L834)

--- a/docs/code/interfaces/types_indexer.AssetResult.md
+++ b/docs/code/interfaces/types_indexer.AssetResult.md
@@ -26,7 +26,7 @@ Round during which this asset was created.
 
 #### Defined in
 
-[src/types/indexer.ts:554](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L554)
+[src/types/indexer.ts:602](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L602)
 
 ___
 
@@ -38,7 +38,7 @@ Whether or not this asset is currently deleted.
 
 #### Defined in
 
-[src/types/indexer.ts:552](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L552)
+[src/types/indexer.ts:600](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L600)
 
 ___
 
@@ -50,7 +50,7 @@ Round during which this asset was destroyed.
 
 #### Defined in
 
-[src/types/indexer.ts:556](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L556)
+[src/types/indexer.ts:604](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L604)
 
 ___
 
@@ -62,7 +62,7 @@ Unique asset identifier.
 
 #### Defined in
 
-[src/types/indexer.ts:550](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L550)
+[src/types/indexer.ts:598](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L598)
 
 ___
 
@@ -74,4 +74,4 @@ The parameters for the asset
 
 #### Defined in
 
-[src/types/indexer.ts:558](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L558)
+[src/types/indexer.ts:606](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L606)

--- a/docs/code/interfaces/types_indexer.AssetTransferTransactionResult.md
+++ b/docs/code/interfaces/types_indexer.AssetTransferTransactionResult.md
@@ -27,7 +27,7 @@ Fields for an asset transfer transaction. https://developer.algorand.org/docs/re
 
 #### Defined in
 
-[src/types/indexer.ts:507](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L507)
+[src/types/indexer.ts:555](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L555)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:509](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L509)
+[src/types/indexer.ts:557](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L557)
 
 ___
 
@@ -51,7 +51,7 @@ Number of assets transfered to the close-to account as part of the transaction.
 
 #### Defined in
 
-[src/types/indexer.ts:511](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L511)
+[src/types/indexer.ts:559](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L559)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:513](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L513)
+[src/types/indexer.ts:561](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L561)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:515](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L515)
+[src/types/indexer.ts:563](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L563)
 
 ___
 
@@ -87,4 +87,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:517](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L517)
+[src/types/indexer.ts:565](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L565)

--- a/docs/code/interfaces/types_indexer.EvalDelta.md
+++ b/docs/code/interfaces/types_indexer.EvalDelta.md
@@ -24,7 +24,7 @@ Represents a TEAL value delta. https://developer.algorand.org/docs/rest-apis/ind
 
 #### Defined in
 
-[src/types/indexer.ts:649](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L649)
+[src/types/indexer.ts:697](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L697)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:651](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L651)
+[src/types/indexer.ts:699](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L699)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:653](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L653)
+[src/types/indexer.ts:701](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L701)

--- a/docs/code/interfaces/types_indexer.EvalDeltaKeyValue.md
+++ b/docs/code/interfaces/types_indexer.EvalDeltaKeyValue.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/types/indexer.ts:635](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L635)
+[src/types/indexer.ts:683](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L683)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:636](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L636)
+[src/types/indexer.ts:684](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L684)

--- a/docs/code/interfaces/types_indexer.HeartbeatTransactionResult.md
+++ b/docs/code/interfaces/types_indexer.HeartbeatTransactionResult.md
@@ -1,0 +1,91 @@
+[@algorandfoundation/algokit-utils](../README.md) / [types/indexer](../modules/types_indexer.md) / HeartbeatTransactionResult
+
+# Interface: HeartbeatTransactionResult
+
+[types/indexer](../modules/types_indexer.md).HeartbeatTransactionResult
+
+Fields for a `hb` transaction https://developer.algorand.org/docs/rest-apis/indexer/#transactionheartbeat
+
+## Table of contents
+
+### Properties
+
+- [hb-address](types_indexer.HeartbeatTransactionResult.md#hb-address)
+- [hb-key-dilution](types_indexer.HeartbeatTransactionResult.md#hb-key-dilution)
+- [hb-proof](types_indexer.HeartbeatTransactionResult.md#hb-proof)
+- [hb-seed](types_indexer.HeartbeatTransactionResult.md#hb-seed)
+- [hb-vote-id](types_indexer.HeartbeatTransactionResult.md#hb-vote-id)
+
+## Properties
+
+### hb-address
+
+• **hb-address**: `string`
+
+[hbad] HbAddress is the account this txn is proving onlineness for.
+
+#### Defined in
+
+[src/types/indexer.ts:417](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L417)
+
+___
+
+### hb-key-dilution
+
+• **hb-key-dilution**: `number`
+
+[hbkd] HbKeyDilution must match HbAddress account's current KeyDilution.
+
+#### Defined in
+
+[src/types/indexer.ts:419](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L419)
+
+___
+
+### hb-proof
+
+• **hb-proof**: `Object`
+
+[hbprf] HbProof is a signature using HeartbeatAddress's partkey, thereby showing it is online.
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `hb-pk?` | `string` | [p] Public key of the heartbeat message. *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\\|[A-Za-z0-9+/]{3}=)?$"` |
+| `hb-pk1sig?` | `string` | [p1s] Signature of OneTimeSignatureSubkeyOffsetID(PK, Batch, Offset) under the key PK2. *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\\|[A-Za-z0-9+/]{3}=)?$"` |
+| `hb-pk2?` | `string` | [p2] Key for new-style two-level ephemeral signature. *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\\|[A-Za-z0-9+/]{3}=)?$"` |
+| `hb-pk2sig?` | `string` | [p2s] Signature of OneTimeSignatureSubkeyBatchID(PK2, Batch) under the master key (OneTimeSignatureVerifier). *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\\|[A-Za-z0-9+/]{3}=)?$"` |
+| `hb-sig?` | `string` | [s] Signature of the heartbeat message. *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\\|[A-Za-z0-9+/]{3}=)?$"` |
+
+#### Defined in
+
+[src/types/indexer.ts:421](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L421)
+
+___
+
+### hb-seed
+
+• **hb-seed**: `string`
+
+[hbsd] HbSeed must be the block seed for the this transaction's firstValid block.
+
+*Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`
+
+#### Defined in
+
+[src/types/indexer.ts:452](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L452)
+
+___
+
+### hb-vote-id
+
+• **hb-vote-id**: `string`
+
+[hbvid] HbVoteID must match the HbAddress account's current VoteID.
+
+*Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`
+
+#### Defined in
+
+[src/types/indexer.ts:457](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L457)

--- a/docs/code/interfaces/types_indexer.KeyRegistrationTransactionResult.md
+++ b/docs/code/interfaces/types_indexer.KeyRegistrationTransactionResult.md
@@ -28,7 +28,7 @@ Fields for a `keyreg` transaction https://developer.algorand.org/docs/rest-apis/
 
 #### Defined in
 
-[src/types/indexer.ts:523](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L523)
+[src/types/indexer.ts:571](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L571)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:528](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L528)
+[src/types/indexer.ts:576](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L576)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:533](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L533)
+[src/types/indexer.ts:581](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L581)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:535](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L535)
+[src/types/indexer.ts:583](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L583)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:537](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L537)
+[src/types/indexer.ts:585](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L585)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:539](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L539)
+[src/types/indexer.ts:587](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L587)
 
 ___
 
@@ -106,4 +106,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:544](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L544)
+[src/types/indexer.ts:592](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L592)

--- a/docs/code/interfaces/types_indexer.LogicTransactionSignature.md
+++ b/docs/code/interfaces/types_indexer.LogicTransactionSignature.md
@@ -29,7 +29,7 @@ https://developer.algorand.org/docs/get-details/transactions/signatures/#logic-s
 
 #### Defined in
 
-[src/types/indexer.ts:593](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L593)
+[src/types/indexer.ts:641](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L641)
 
 ___
 
@@ -45,7 +45,7 @@ Base64 encoded TEAL program.
 
 #### Defined in
 
-[src/types/indexer.ts:600](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L600)
+[src/types/indexer.ts:648](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L648)
 
 ___
 
@@ -57,7 +57,7 @@ The signature of the multisig the logic signature delegating the logicsig. https
 
 #### Defined in
 
-[src/types/indexer.ts:602](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L602)
+[src/types/indexer.ts:650](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L650)
 
 ___
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:607](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L607)
+[src/types/indexer.ts:655](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L655)

--- a/docs/code/interfaces/types_indexer.MerkleArrayProof.md
+++ b/docs/code/interfaces/types_indexer.MerkleArrayProof.md
@@ -64,7 +64,7 @@ The worst case is this:
 
 #### Defined in
 
-[src/types/indexer.ts:451](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L451)
+[src/types/indexer.ts:499](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L499)
 
 ___
 
@@ -78,7 +78,7 @@ the path length can increase up to 2^MaxEncodedTreeDepth / 2
 
 #### Defined in
 
-[src/types/indexer.ts:459](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L459)
+[src/types/indexer.ts:507](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L507)
 
 ___
 
@@ -91,4 +91,4 @@ It is the number of edges from the root to a leaf.
 
 #### Defined in
 
-[src/types/indexer.ts:463](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L463)
+[src/types/indexer.ts:511](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L511)

--- a/docs/code/interfaces/types_indexer.MiniAssetHolding.md
+++ b/docs/code/interfaces/types_indexer.MiniAssetHolding.md
@@ -27,7 +27,7 @@ Address of the account that holds the asset.
 
 #### Defined in
 
-[src/types/indexer.ts:877](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L877)
+[src/types/indexer.ts:925](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L925)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:881](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L881)
+[src/types/indexer.ts:929](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L929)
 
 ___
 
@@ -51,7 +51,7 @@ Whether or not the asset holding is currently deleted from its account.
 
 #### Defined in
 
-[src/types/indexer.ts:883](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L883)
+[src/types/indexer.ts:931](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L931)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:887](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L887)
+[src/types/indexer.ts:935](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L935)
 
 ___
 
@@ -75,7 +75,7 @@ Round during which the account opted into this asset holding.
 
 #### Defined in
 
-[src/types/indexer.ts:889](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L889)
+[src/types/indexer.ts:937](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L937)
 
 ___
 
@@ -87,4 +87,4 @@ Round during which the account opted out of this asset holding.
 
 #### Defined in
 
-[src/types/indexer.ts:891](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L891)
+[src/types/indexer.ts:939](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L939)

--- a/docs/code/interfaces/types_indexer.MultisigTransactionSignature.md
+++ b/docs/code/interfaces/types_indexer.MultisigTransactionSignature.md
@@ -24,7 +24,7 @@
 
 #### Defined in
 
-[src/types/indexer.ts:613](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L613)
+[src/types/indexer.ts:661](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L661)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:615](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L615)
+[src/types/indexer.ts:663](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L663)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:617](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L617)
+[src/types/indexer.ts:665](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L665)

--- a/docs/code/interfaces/types_indexer.MultisigTransactionSubSignature.md
+++ b/docs/code/interfaces/types_indexer.MultisigTransactionSubSignature.md
@@ -25,7 +25,7 @@ Sub-signature for a multisig signature https://developer.algorand.org/docs/rest-
 
 #### Defined in
 
-[src/types/indexer.ts:626](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L626)
+[src/types/indexer.ts:674](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L674)
 
 ___
 
@@ -39,4 +39,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:631](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L631)
+[src/types/indexer.ts:679](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L679)

--- a/docs/code/interfaces/types_indexer.PaymentTransactionResult.md
+++ b/docs/code/interfaces/types_indexer.PaymentTransactionResult.md
@@ -25,7 +25,7 @@ Fields for a payment transaction https://developer.algorand.org/docs/rest-apis/i
 
 #### Defined in
 
-[src/types/indexer.ts:288](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L288)
+[src/types/indexer.ts:290](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L290)
 
 ___
 
@@ -37,7 +37,7 @@ Number of µAlgo that were sent to the close-remainder-to address when closing t
 
 #### Defined in
 
-[src/types/indexer.ts:290](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L290)
+[src/types/indexer.ts:292](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L292)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:292](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L292)
+[src/types/indexer.ts:294](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L294)
 
 ___
 
@@ -61,4 +61,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:294](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L294)
+[src/types/indexer.ts:296](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L296)

--- a/docs/code/interfaces/types_indexer.StateProofTransactionResult.md
+++ b/docs/code/interfaces/types_indexer.StateProofTransactionResult.md
@@ -47,7 +47,7 @@ are needed in order to verify the next state proofs (VotersCommitment and LnProv
 
 #### Defined in
 
-[src/types/indexer.ts:315](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L315)
+[src/types/indexer.ts:317](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L317)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:330](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L330)
+[src/types/indexer.ts:332](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L332)
 
 ___
 
@@ -85,4 +85,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:409](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L409)
+[src/types/indexer.ts:411](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L411)

--- a/docs/code/interfaces/types_indexer.StateSchema.md
+++ b/docs/code/interfaces/types_indexer.StateSchema.md
@@ -28,7 +28,7 @@ Maximum number of TEAL byte slices that may be stored in the key/value store.
 
 #### Defined in
 
-[src/types/indexer.ts:699](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L699)
+[src/types/indexer.ts:747](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L747)
 
 ___
 
@@ -40,4 +40,4 @@ Maximum number of TEAL uints that may be stored in the key/value store.
 
 #### Defined in
 
-[src/types/indexer.ts:701](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L701)
+[src/types/indexer.ts:749](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L749)

--- a/docs/code/interfaces/types_indexer.TransactionResult.md
+++ b/docs/code/interfaces/types_indexer.TransactionResult.md
@@ -32,6 +32,7 @@ Indexer result for a transaction, https://developer.algorand.org/docs/rest-apis/
 - [genesis-id](types_indexer.TransactionResult.md#genesis-id)
 - [global-state-delta](types_indexer.TransactionResult.md#global-state-delta)
 - [group](types_indexer.TransactionResult.md#group)
+- [heartbeat-transaction](types_indexer.TransactionResult.md#heartbeat-transaction)
 - [id](types_indexer.TransactionResult.md#id)
 - [inner-txns](types_indexer.TransactionResult.md#inner-txns)
 - [intra-round-offset](types_indexer.TransactionResult.md#intra-round-offset)
@@ -110,7 +111,7 @@ The backend can use this to ensure that auth addr is equal to the accounts auth 
 
 #### Defined in
 
-[src/types/indexer.ts:170](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L170)
+[src/types/indexer.ts:172](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L172)
 
 ___
 
@@ -122,7 +123,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:205](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L205)
+[src/types/indexer.ts:207](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L207)
 
 ___
 
@@ -134,7 +135,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:172](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L172)
+[src/types/indexer.ts:174](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L174)
 
 ___
 
@@ -210,7 +211,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:177](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L177)
+[src/types/indexer.ts:179](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L179)
 
 ___
 
@@ -222,7 +223,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:179](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L179)
+[src/types/indexer.ts:181](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L181)
 
 ___
 
@@ -234,7 +235,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:199](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L199)
+[src/types/indexer.ts:201](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L201)
 
 ___
 
@@ -252,6 +253,18 @@ When present indicates that this transaction is part of a transaction group
 #### Defined in
 
 [src/types/indexer.ts:130](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L130)
+
+___
+
+### heartbeat-transaction
+
+• `Optional` **heartbeat-transaction**: [`HeartbeatTransactionResult`](types_indexer.HeartbeatTransactionResult.md)
+
+If the transaction is a `hb` transaction this will be populated see `tx-type`
+
+#### Defined in
+
+[src/types/indexer.ts:168](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L168)
 
 ___
 
@@ -275,7 +288,7 @@ Inner transactions produced by application execution.
 
 #### Defined in
 
-[src/types/indexer.ts:181](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L181)
+[src/types/indexer.ts:183](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L183)
 
 ___
 
@@ -330,7 +343,7 @@ While this transaction possesses the lease, no other transaction specifying this
 
 #### Defined in
 
-[src/types/indexer.ts:195](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L195)
+[src/types/indexer.ts:197](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L197)
 
 ___
 
@@ -342,7 +355,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:197](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L197)
+[src/types/indexer.ts:199](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L199)
 
 ___
 
@@ -392,7 +405,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:201](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L201)
+[src/types/indexer.ts:203](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L203)
 
 ___
 
@@ -405,7 +418,7 @@ this value and future signatures must be signed with the key represented by this
 
 #### Defined in
 
-[src/types/indexer.ts:185](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L185)
+[src/types/indexer.ts:187](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L187)
 
 ___
 
@@ -441,7 +454,7 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:203](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L203)
+[src/types/indexer.ts:205](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L205)
 
 ___
 

--- a/docs/code/interfaces/types_indexer.TransactionSignature.md
+++ b/docs/code/interfaces/types_indexer.TransactionSignature.md
@@ -24,7 +24,7 @@ Logicsig signature
 
 #### Defined in
 
-[src/types/indexer.ts:575](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L575)
+[src/types/indexer.ts:623](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L623)
 
 ___
 
@@ -36,7 +36,7 @@ Multisig signature
 
 #### Defined in
 
-[src/types/indexer.ts:577](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L577)
+[src/types/indexer.ts:625](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L625)
 
 ___
 
@@ -50,4 +50,4 @@ ___
 
 #### Defined in
 
-[src/types/indexer.ts:582](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L582)
+[src/types/indexer.ts:630](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L630)

--- a/docs/code/modules/types_indexer.md
+++ b/docs/code/modules/types_indexer.md
@@ -34,6 +34,7 @@
 - [AssetsLookupResult](../interfaces/types_indexer.AssetsLookupResult.md)
 - [EvalDelta](../interfaces/types_indexer.EvalDelta.md)
 - [EvalDeltaKeyValue](../interfaces/types_indexer.EvalDeltaKeyValue.md)
+- [HeartbeatTransactionResult](../interfaces/types_indexer.HeartbeatTransactionResult.md)
 - [KeyRegistrationTransactionResult](../interfaces/types_indexer.KeyRegistrationTransactionResult.md)
 - [LogicTransactionSignature](../interfaces/types_indexer.LogicTransactionSignature.md)
 - [LookupAssetHoldingsOptions](../interfaces/types_indexer.LookupAssetHoldingsOptions.md)
@@ -61,4 +62,4 @@
 
 #### Defined in
 
-[src/types/indexer.ts:644](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L644)
+[src/types/indexer.ts:692](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/indexer.ts#L692)

--- a/src/types/indexer.ts
+++ b/src/types/indexer.ts
@@ -164,6 +164,8 @@ export interface TransactionResult extends Record<string, any> {
   'payment-transaction'?: PaymentTransactionResult
   /** If the transaction is a `stpf` transaction this will be populated see `tx-type` */
   'state-proof-transaction'?: StateProofTransactionResult
+  /** If the transaction is a `hb` transaction this will be populated see `tx-type` */
+  'heartbeat-transaction'?: HeartbeatTransactionResult
   /** [sgnr] this is included with signed transactions when the signing address does not equal the sender.
    * The backend can use this to ensure that auth addr is equal to the accounts auth addr.
    */
@@ -407,6 +409,52 @@ export interface StateProofTransactionResult {
    *  * 0: StateProofBasic is our initial state proof setup. using falcon keys and subset-sum hash
    */
   'state-proof-type': number
+}
+
+/** Fields for a `hb` transaction https://developer.algorand.org/docs/rest-apis/indexer/#transactionheartbeat */
+export interface HeartbeatTransactionResult {
+  /** [hbad] HbAddress is the account this txn is proving onlineness for. */
+  'hb-address': string
+  /** [hbkd] HbKeyDilution must match HbAddress account's current KeyDilution. */
+  'hb-key-dilution': number
+  /** [hbprf] HbProof is a signature using HeartbeatAddress's partkey, thereby showing it is online. */
+  'hb-proof': {
+    /** [p] Public key of the heartbeat message.
+     *
+     * *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`
+     */
+    'hb-pk'?: string
+    /** [p1s] Signature of OneTimeSignatureSubkeyOffsetID(PK, Batch, Offset) under the key PK2.
+     *
+     * *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`
+     */
+    'hb-pk1sig'?: string
+    /** [p2] Key for new-style two-level ephemeral signature.
+     *
+     * *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`
+     */
+    'hb-pk2'?: string
+    /** [p2s] Signature of OneTimeSignatureSubkeyBatchID(PK2, Batch) under the master key (OneTimeSignatureVerifier).
+     *
+     * *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`
+     */
+    'hb-pk2sig'?: string
+    /** [s] Signature of the heartbeat message.
+     *
+     * *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`
+     */
+    'hb-sig'?: string
+  }
+  /** [hbsd] HbSeed must be the block seed for the this transaction's firstValid block.
+   *
+   * *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`
+   */
+  'hb-seed': string
+  /** [hbvid] HbVoteID must match the HbAddress account's current VoteID.
+   *
+   * *Pattern:* `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`
+   */
+  'hb-vote-id': string
 }
 
 /**


### PR DESCRIPTION
Adding heartbeat transaction data to the indexer types.
This change is only required in v7 (hence `main-v7` target), as v8 leverages the indexer types introduced in algosdk@3.