### PR TITLE
fix: Throw a more helpful error message when a client consumer passes in unexpected args

### DIFF
--- a/docs/code/classes/types_app_client.AppClient.md
+++ b/docs/code/classes/types_app_client.AppClient.md
@@ -686,7 +686,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1428](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1428)
+[src/types/app-client.ts:1431](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1431)
 
 ___
 
@@ -709,7 +709,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1138](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1138)
+[src/types/app-client.ts:1141](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1141)
 
 ___
 
@@ -737,7 +737,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1415](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1415)
+[src/types/app-client.ts:1418](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1418)
 
 ___
 
@@ -760,7 +760,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1103)
+[src/types/app-client.ts:1106](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1106)
 
 ___
 
@@ -783,7 +783,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1167](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1167)
+[src/types/app-client.ts:1170](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1170)
 
 ___
 
@@ -804,7 +804,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1469](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1469)
+[src/types/app-client.ts:1472](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1472)
 
 ___
 
@@ -987,7 +987,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1357](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1357)
+[src/types/app-client.ts:1360](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1360)
 
 ___
 
@@ -1010,7 +1010,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1200](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1200)
+[src/types/app-client.ts:1203](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1203)
 
 ___
 
@@ -1033,7 +1033,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1240](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1240)
+[src/types/app-client.ts:1243](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1243)
 
 ___
 
@@ -1056,7 +1056,7 @@ if none provided and throws an error if neither provided
 
 #### Defined in
 
-[src/types/app-client.ts:1398](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1398)
+[src/types/app-client.ts:1401](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1401)
 
 ___
 
@@ -1081,7 +1081,7 @@ or `undefined` otherwise (so the signer is resolved from `AlgorandClient`)
 
 #### Defined in
 
-[src/types/app-client.ts:1408](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1408)
+[src/types/app-client.ts:1411](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1411)
 
 ___
 
@@ -1110,7 +1110,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1541](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1541)
+[src/types/app-client.ts:1544](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1544)
 
 ___
 
@@ -1138,7 +1138,7 @@ Make the given call and catch any errors, augmenting with debugging information 
 
 #### Defined in
 
-[src/types/app-client.ts:1452](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1452)
+[src/types/app-client.ts:1455](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1455)
 
 ___
 

--- a/docs/code/classes/types_app_client.ApplicationClient.md
+++ b/docs/code/classes/types_app_client.ApplicationClient.md
@@ -92,7 +92,7 @@ Create a new ApplicationClient instance
 
 #### Defined in
 
-[src/types/app-client.ts:1668](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1668)
+[src/types/app-client.ts:1671](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1671)
 
 ## Properties
 
@@ -102,7 +102,7 @@ Create a new ApplicationClient instance
 
 #### Defined in
 
-[src/types/app-client.ts:1651](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1651)
+[src/types/app-client.ts:1654](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1654)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1650](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1650)
+[src/types/app-client.ts:1653](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1653)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1653](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1653)
+[src/types/app-client.ts:1656](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1656)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1655](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1655)
+[src/types/app-client.ts:1658](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1658)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1656](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1656)
+[src/types/app-client.ts:1659](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1659)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1652](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1652)
+[src/types/app-client.ts:1655](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1655)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1642](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1642)
+[src/types/app-client.ts:1645](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1645)
 
 ___
 
@@ -172,7 +172,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1644](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1644)
+[src/types/app-client.ts:1647](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1647)
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1648](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1648)
+[src/types/app-client.ts:1651](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1651)
 
 ___
 
@@ -192,7 +192,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1647](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1647)
+[src/types/app-client.ts:1650](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1650)
 
 ___
 
@@ -202,7 +202,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1643](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1643)
+[src/types/app-client.ts:1646](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1646)
 
 ___
 
@@ -212,7 +212,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1646](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1646)
+[src/types/app-client.ts:1649](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1649)
 
 ___
 
@@ -222,7 +222,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:1645](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1645)
+[src/types/app-client.ts:1648](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1648)
 
 ## Methods
 
@@ -250,7 +250,7 @@ Issues a no_op (normal) call to the app.
 
 #### Defined in
 
-[src/types/app-client.ts:1991](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1991)
+[src/types/app-client.ts:1994](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1994)
 
 ___
 
@@ -279,7 +279,7 @@ Issues a call to the app with the given call type.
 
 #### Defined in
 
-[src/types/app-client.ts:2073](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2073)
+[src/types/app-client.ts:2076](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2076)
 
 ___
 
@@ -307,7 +307,7 @@ Issues a clear_state call to the app.
 
 #### Defined in
 
-[src/types/app-client.ts:2050](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2050)
+[src/types/app-client.ts:2053](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2053)
 
 ___
 
@@ -335,7 +335,7 @@ Issues a close_out call to the app.
 
 #### Defined in
 
-[src/types/app-client.ts:2039](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2039)
+[src/types/app-client.ts:2042](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2042)
 
 ___
 
@@ -363,7 +363,7 @@ Compiles the approval and clear state programs and sets up the source map.
 
 #### Defined in
 
-[src/types/app-client.ts:1707](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1707)
+[src/types/app-client.ts:1710](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1710)
 
 ___
 
@@ -391,7 +391,7 @@ Creates a smart contract app, returns the details of the created app.
 
 #### Defined in
 
-[src/types/app-client.ts:1886](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1886)
+[src/types/app-client.ts:1889](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1889)
 
 ___
 
@@ -419,7 +419,7 @@ Issues a delete_application call to the app.
 
 #### Defined in
 
-[src/types/app-client.ts:2061](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2061)
+[src/types/app-client.ts:2064](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2064)
 
 ___
 
@@ -453,7 +453,7 @@ To understand the architecture decisions behind this functionality please see ht
 
 #### Defined in
 
-[src/types/app-client.ts:1775](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1775)
+[src/types/app-client.ts:1778](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1778)
 
 ___
 
@@ -471,7 +471,7 @@ The source maps
 
 #### Defined in
 
-[src/types/app-client.ts:1740](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1740)
+[src/types/app-client.ts:1743](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1743)
 
 ___
 
@@ -498,7 +498,7 @@ The new error, or if there was no logic error or source map then the wrapped err
 
 #### Defined in
 
-[src/types/app-client.ts:2395](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2395)
+[src/types/app-client.ts:2398](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2398)
 
 ___
 
@@ -522,7 +522,7 @@ The result of the funding
 
 #### Defined in
 
-[src/types/app-client.ts:2112](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2112)
+[src/types/app-client.ts:2115](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2115)
 
 ___
 
@@ -546,7 +546,7 @@ The ABI method for the given method
 
 #### Defined in
 
-[src/types/app-client.ts:2353](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2353)
+[src/types/app-client.ts:2356](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2356)
 
 ___
 
@@ -574,7 +574,7 @@ Returns the ABI Method parameters for the given method name string for the app r
 
 #### Defined in
 
-[src/types/app-client.ts:2331](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2331)
+[src/types/app-client.ts:2334](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2334)
 
 ___
 
@@ -594,7 +594,7 @@ ___
 
 #### Defined in
 
-[src/types/app-client.ts:2411](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2411)
+[src/types/app-client.ts:2414](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2414)
 
 ___
 
@@ -617,7 +617,7 @@ Gets the reference information for the current application instance.
 
 #### Defined in
 
-[src/types/app-client.ts:2365](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2365)
+[src/types/app-client.ts:2368](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2368)
 
 ___
 
@@ -635,7 +635,7 @@ The names of the boxes
 
 #### Defined in
 
-[src/types/app-client.ts:2168](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2168)
+[src/types/app-client.ts:2171](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2171)
 
 ___
 
@@ -659,7 +659,7 @@ The current box value as a byte array
 
 #### Defined in
 
-[src/types/app-client.ts:2183](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2183)
+[src/types/app-client.ts:2186](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2186)
 
 ___
 
@@ -684,7 +684,7 @@ The current box value as a byte array
 
 #### Defined in
 
-[src/types/app-client.ts:2199](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2199)
+[src/types/app-client.ts:2202](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2202)
 
 ___
 
@@ -709,7 +709,7 @@ The (name, value) pair of the boxes with values as raw byte arrays
 
 #### Defined in
 
-[src/types/app-client.ts:2215](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2215)
+[src/types/app-client.ts:2218](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2218)
 
 ___
 
@@ -735,7 +735,7 @@ The (name, value) pair of the boxes with values as the ABI Value
 
 #### Defined in
 
-[src/types/app-client.ts:2237](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2237)
+[src/types/app-client.ts:2240](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2240)
 
 ___
 
@@ -764,7 +764,7 @@ Returns the arguments for an app call for the given ABI method or raw method spe
 
 #### Defined in
 
-[src/types/app-client.ts:2261](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2261)
+[src/types/app-client.ts:2264](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2264)
 
 ___
 
@@ -782,7 +782,7 @@ The global state
 
 #### Defined in
 
-[src/types/app-client.ts:2140](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2140)
+[src/types/app-client.ts:2143](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2143)
 
 ___
 
@@ -806,7 +806,7 @@ The global state
 
 #### Defined in
 
-[src/types/app-client.ts:2154](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2154)
+[src/types/app-client.ts:2157](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2157)
 
 ___
 
@@ -828,7 +828,7 @@ Import source maps for the app.
 
 #### Defined in
 
-[src/types/app-client.ts:1757](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1757)
+[src/types/app-client.ts:1760](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1760)
 
 ___
 
@@ -856,7 +856,7 @@ Issues a opt_in call to the app.
 
 #### Defined in
 
-[src/types/app-client.ts:2028](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2028)
+[src/types/app-client.ts:2031](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L2031)
 
 ___
 
@@ -884,4 +884,4 @@ Updates the smart contract app.
 
 #### Defined in
 
-[src/types/app-client.ts:1950](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1950)
+[src/types/app-client.ts:1953](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-client.ts#L1953)

--- a/src/types/app-client.ts
+++ b/src/types/app-client.ts
@@ -1035,6 +1035,9 @@ export class AppClient {
     return await Promise.all(
       args?.map(async (a, i) => {
         const arg = m.args[i]
+        if (!arg) {
+          throw new Error(`Unexpected arg at position ${i}. ${m.name} only expects ${m.args.length} args`)
+        }
         if (a !== undefined) {
           // If a struct then convert to tuple for the underlying call
           return arg.struct && typeof a === 'object' && !Array.isArray(a)

--- a/src/types/app-factory-and-client.spec.ts
+++ b/src/types/app-factory-and-client.spec.ts
@@ -303,6 +303,22 @@ describe('ARC32: app-factory-and-app-client', () => {
     invariant(call.return)
     expect(call.return).toBe('Hello, test')
   })
+  test('Call app too many args', async () => {
+    const { appClient } = await factory.send.bare.create({
+      deployTimeParams: {
+        UPDATABLE: 0,
+        DELETABLE: 0,
+        VALUE: 1,
+      },
+    })
+
+    await expect(
+      appClient.send.call({
+        method: 'call_abi',
+        args: ['test', 'extra'],
+      }),
+    ).rejects.toThrow('Unexpected arg at position 1. call_abi only expects 1 args')
+  })
 
   test('Call app with rekey', async () => {
     const { testAccount, algorand } = localnet.context


### PR DESCRIPTION
Currently if you pass extra args into an abi call (eg. because you passed `args: [1, 2, 3]` instead of `args: [[1, 2, 3]]` for an array arg) the error you receive is `TypeError: Cannot read properties of undefined (reading 'struct')` as the arg mapping logic attempts to read metadata for an undefined arg.

This PR tweaks the mapping logic to throw a more helpful error when this occurs. The message will instead read something to the effect of `Unexpected arg at position 1. your_method only expects 1 args`
