### PR TITLE
feat: use algod's resoure population

### DIFF
--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -487,6 +487,11 @@ export async function prepareGroupForSending(
 
   // Populate Group App Call Resources
   if (executionInfo.populatedResourceArrays) {
+    // In the future, we could just add the txns to the group. Perhaps this would be a seperate option in addition to populateAppCallResources
+    if (executionInfo.extraResourceArrays?.length || 0 != 0) {
+      throw Error('Transaction group requires extra transactions to name all resources. Empty app calls must be added to the group')
+    }
+
     executionInfo.populatedResourceArrays.forEach((r, i) => {
       const txn = group[i].txn.applicationCall
       if (r === undefined || txn === undefined) return


### PR DESCRIPTION
## Proposed Changes

- Uses algod's resource population mechanism instead of doing it client side. 

Algod's algorithim is better tested and enables deterministic population (i.e. the same group always gets the same resources/order). 

Depends on https://github.com/algorand/js-algorand-sdk/pull/948, which depends on https://github.com/algorand/algorand-sdk-testing/pull/319, which depends on https://github.com/algorand/go-algorand/pull/6015