### PR TITLE
feat: simulate transaction group via core

### DIFF
--- a/docs/code/classes/types_composer.TransactionComposer.md
+++ b/docs/code/classes/types_composer.TransactionComposer.md
@@ -2043,4 +2043,4 @@ The binary encoded transaction note
 
 #### Defined in
 
-[src/types/composer.ts:2267](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/composer.ts#L2267)
+[src/types/composer.ts:2277](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/composer.ts#L2277)

--- a/package.json
+++ b/package.json
@@ -69,13 +69,13 @@
     "buffer": "^6.0.3"
   },
   "peerDependencies": {
-    "@algorandfoundation/algokit-algod-api": "^1.0.0-alpha.16",
     "@algorandfoundation/algokit-transact": "^1.0.0-alpha.18",
+    "@algorandfoundation/algokit-algod-api": "^1.0.0-alpha.16",
     "algosdk": "^3.0.0"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-algod-api": "^1.0.0-alpha.16",
     "@algorandfoundation/algokit-transact": "^1.0.0-alpha.18",
+    "@algorandfoundation/algokit-algod-api": "^1.0.0-alpha.16",
     "@algorandfoundation/tealscript": "^0.106.3",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",

--- a/src/algokit-core-bridge/perform-atomic-transaction-composer-simulate.ts
+++ b/src/algokit-core-bridge/perform-atomic-transaction-composer-simulate.ts
@@ -1,5 +1,5 @@
 import { AlgodApi, SimulateRequest, SimulateRequestTransactionGroup, SimulateTraceConfig } from '@algorandfoundation/algokit-algod-api'
-import { Transaction as AlgoKitCoreTransaction, encodeSignedTransaction } from '@algorandfoundation/algokit-transact'
+import { Transaction as AlgoKitCoreTransaction, encodeSignedTransactions } from '@algorandfoundation/algokit-transact'
 import algosdk from 'algosdk'
 import { handleMsgPackResponse } from '../algokit-core-bridge/algod-request-proxies/utils'
 
@@ -15,7 +15,8 @@ export async function performAlgoKitCoreAtomicTransactionComposerSimulate(
   transactions: AlgoKitCoreTransaction[],
   algod: AlgodApi,
 ): Promise<algosdk.modelsv2.SimulateResponse> {
-  const encodedSignedTransactions = transactions.map((txn) => encodeSignedTransaction({ transaction: txn }))
+  // Encoded with an empty signer, as we have allowEmptySignatures enabled
+  const encodedSignedTransactions = encodeSignedTransactions(transactions.map((txn) => ({ transaction: txn })))
 
   const simulateRequest = {
     allowEmptySignatures: true,

--- a/src/types/composer.spec.ts
+++ b/src/types/composer.spec.ts
@@ -1,11 +1,13 @@
+import algosdk from 'algosdk'
 import { beforeEach, describe, expect, test } from 'vitest'
 import { algorandFixture } from '../algokit-core-bridge/algorand-fixture'
+import { AlgoAmount } from './amount'
 
 describe('TransactionComposer', () => {
   const fixture = algorandFixture()
 
   beforeEach(async () => {
-    await fixture.beforeEach()
+    await fixture.newScope()
   })
 
   describe('error transformers', () => {
@@ -62,6 +64,173 @@ describe('TransactionComposer', () => {
       })
 
       await expect(composer.send()).rejects.toThrow('ASSET MISSING!')
+    })
+  })
+
+  describe('payment transaction groups', () => {
+    const amount = AlgoAmount.Algo(0.01)
+
+    test('send single', async () => {
+      const { algorand, testAccount: sender, generateAccount } = fixture.context
+      const receiver = await generateAccount({ initialFunds: AlgoAmount.Algo(1) })
+
+      const result = await algorand
+        .newGroup()
+        .addPayment({
+          sender,
+          receiver,
+          amount,
+        })
+        .send()
+
+      expect(result.groupId).toBeFalsy() // A single transaction is not grouped
+      expect(result.txIds).toHaveLength(1)
+
+      expect(result.transactions).toHaveLength(1)
+      expect(result.transactions[0].type).toBe(algosdk.TransactionType.pay)
+      expect(result.transactions[0].sender.toString()).toBe(sender.toString())
+      expect(result.transactions[0].payment?.receiver?.toString()).toBe(receiver.toString())
+      expect(result.transactions[0].payment?.amount).toBe(amount.microAlgo)
+      expect(result.transactions[0].group).toBeFalsy()
+
+      expect(result.confirmations).toHaveLength(1)
+      expect(result.confirmations[0].confirmedRound).toBeGreaterThan(0n)
+    })
+
+    test('simulate single', async () => {
+      const { algorand, testAccount: sender, generateAccount } = fixture.context
+      const receiver = await generateAccount({ initialFunds: AlgoAmount.Algo(1) })
+
+      const result = await algorand
+        .newGroup()
+        .addPayment({
+          sender,
+          receiver,
+          amount,
+        })
+        .simulate()
+
+      expect(result.groupId).toBeFalsy() // A single transaction is not grouped
+      expect(result.txIds).toHaveLength(1)
+
+      expect(result.simulateResponse).toBeDefined()
+      expect(result.simulateResponse.txnGroups).toHaveLength(1)
+
+      expect(result.transactions).toHaveLength(1)
+      expect(result.transactions[0].type).toBe(algosdk.TransactionType.pay)
+      expect(result.transactions[0].sender.toString()).toBe(sender.toString())
+      expect(result.transactions[0].payment?.receiver?.toString()).toBe(receiver.toString())
+      expect(result.transactions[0].payment?.amount).toBe(amount.microAlgo)
+      expect(result.transactions[0].group).toBeFalsy()
+
+      expect(result.confirmations).toHaveLength(1)
+      expect(result.confirmations[0].confirmedRound).toBeUndefined()
+    })
+
+    test('send multiple', async () => {
+      const { algorand, testAccount: sender, generateAccount } = fixture.context
+      const receiver = await generateAccount({ initialFunds: AlgoAmount.Algo(1) })
+
+      const result = await algorand
+        .newGroup()
+        .addPayment({
+          sender,
+          receiver,
+          amount,
+          note: 'Payment 1',
+        })
+        .addPayment({
+          sender,
+          receiver,
+          amount,
+          note: 'Payment 2',
+        })
+        .send()
+
+      expect(result.groupId).toBeTruthy()
+      expect(result.txIds).toHaveLength(2)
+
+      expect(result.transactions).toHaveLength(2)
+      result.transactions.forEach((txn) => {
+        expect(txn.type).toBe(algosdk.TransactionType.pay)
+        expect(txn.sender.toString()).toBe(sender.toString())
+        expect(txn.payment?.receiver?.toString()).toBe(receiver.toString())
+        expect(txn.payment?.amount).toBe(amount.microAlgo)
+        expect(txn.group).toBeTruthy()
+        expect(Buffer.from(txn.group!).toString('base64')).toBe(result.groupId)
+      })
+
+      expect(result.confirmations).toHaveLength(2)
+      result.confirmations.forEach((confirmation) => {
+        expect(confirmation.confirmedRound).toBeGreaterThan(0n)
+      })
+    })
+
+    test('simulate multiple', async () => {
+      const { algorand, testAccount: sender, generateAccount } = fixture.context
+      const receiver = await generateAccount({ initialFunds: AlgoAmount.Algo(1) })
+
+      const result = await algorand
+        .newGroup()
+        .addPayment({
+          sender,
+          receiver,
+          amount,
+          note: 'Simulated payment 1',
+        })
+        .addPayment({
+          sender,
+          receiver,
+          amount,
+          note: 'Simulated payment 2',
+        })
+        .simulate()
+
+      expect(result.groupId).toBeTruthy()
+      expect(result.txIds).toHaveLength(2)
+
+      expect(result.simulateResponse).toBeDefined()
+      expect(result.simulateResponse.txnGroups).toHaveLength(1)
+
+      expect(result.transactions).toHaveLength(2)
+      result.transactions.forEach((txn) => {
+        expect(txn.type).toBe(algosdk.TransactionType.pay)
+        expect(txn.sender.toString()).toBe(sender.toString())
+        expect(txn.payment?.receiver?.toString()).toBe(receiver.toString())
+        expect(txn.payment?.amount).toBe(amount.microAlgo)
+        expect(txn.group).toBeTruthy()
+        expect(Buffer.from(txn.group!).toString('base64')).toBe(result.groupId)
+      })
+
+      expect(result.confirmations).toHaveLength(2)
+      result.confirmations.forEach((confirmation) => {
+        expect(confirmation.confirmedRound).toBeUndefined()
+      })
+    })
+
+    test('simulate with skipSignatures', async () => {
+      const { algorand, testAccount: sender, generateAccount } = fixture.context
+      const receiver = await generateAccount({ initialFunds: AlgoAmount.Algo(1) })
+
+      const result = await algorand
+        .newGroup()
+        .addPayment({
+          sender,
+          receiver,
+          amount,
+          // Attach a signer, which produces an invalid signature
+          signer: () => {
+            return Promise.resolve([new Uint8Array([1, 2, 3])])
+          },
+        })
+        .simulate({ skipSignatures: true })
+
+      expect(result.simulateResponse).toBeDefined()
+      expect(result.simulateResponse.txnGroups).toHaveLength(1)
+
+      expect(result.transactions).toHaveLength(1)
+
+      expect(result.confirmations).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
Add simulate support for payment transaction groups via the core composer.