### PR TITLE
chore: update resource population account limit

### DIFF
--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -36,7 +36,7 @@ import TransactionWithSigner = algosdk.TransactionWithSigner
 
 export const MAX_TRANSACTION_GROUP_SIZE = 16
 export const MAX_APP_CALL_FOREIGN_REFERENCES = 8
-export const MAX_APP_CALL_ACCOUNT_REFERENCES = 4
+export const MAX_APP_CALL_ACCOUNT_REFERENCES = 8
 
 /**
  * @deprecated Convert your data to a `string` or `Uint8Array`, if using ARC-2 use `TransactionComposer.arc2Note`.


### PR DESCRIPTION
With the 4.3.0 updates, app call transactions can have up to 8 account references.
~NOTE: This change should not be merged until mainnet has been upgraded.~ update has been rolled out, have also run a test on mainnet to confirm.