### PR TITLE
fix: handle no signer

### DIFF
--- a/docs/code/classes/types_composer.TransactionComposer.md
+++ b/docs/code/classes/types_composer.TransactionComposer.md
@@ -1748,7 +1748,7 @@ ___
 
 #### Defined in
 
-[src/types/composer.ts:2157](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/composer.ts#L2157)
+[src/types/composer.ts:2171](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/composer.ts#L2171)
 
 ___
 
@@ -1902,7 +1902,7 @@ ___
 
 #### Defined in
 
-[src/types/composer.ts:2175](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/composer.ts#L2175)
+[src/types/composer.ts:2189](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/composer.ts#L2189)
 
 ___
 


### PR DESCRIPTION
The previous code would throw a "undefined is not iterable (cannot read property Symbol(Symbol.iterator))" when trying to sign a transaction without a signer being available.

This was due to the below line:
```ts
const stxn = decodeSignedTransaction(stxs[stxIndex])
```
`stxs[stxIndex]` returns `undefined` for the transaction index where no signer is available. An exception is then thrown in `decodeSignedTransaction` as you cannot msgpack decode the value `undefined`.