### PR TITLE
Docs/add addtional typedoc tags

### DIFF
--- a/packages/abi/src/abi-method.ts
+++ b/packages/abi/src/abi-method.ts
@@ -124,6 +124,7 @@ export class ABIMethod {
    * @param signature The method signature
    * e.g. `my_method(unit64,string)bytes`
    * @returns The `ABIMethod`
+   * @throws {Error} If the method signature is invalid
    */
   static fromSignature(signature: string): ABIMethod {
     const argsStart = signature.indexOf('(')
@@ -180,6 +181,7 @@ export class ABIMethod {
  * e.g. `my_method` or `my_method(unit64,string)bytes`
  * @param appSpec The app spec for the app
  * @returns The `ABIMethod`
+ * @throws {Error} If the method is not found in the app spec or if method name resolves to multiple methods
  */
 export function getABIMethod(methodNameOrSignature: string, appSpec: Arc56Contract): ABIMethod {
   if (!methodNameOrSignature.includes('(')) {

--- a/packages/abi/src/abi-type.ts
+++ b/packages/abi/src/abi-type.ts
@@ -99,6 +99,11 @@ export abstract class ABIType {
    * @param str The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
    * @returns The corresponding ABI type
    * @throws {Error} If the type string is malformed or unsupported
+   *
+   * @remarks
+   * Supported type formats include: `uint<N>` (8-512 bits), `ufixed<N>x<M>`, `bool`, `byte`,
+   * `address`, `string`, `<type>[<N>]` (static arrays), `<type>[]` (dynamic arrays),
+   * and `(<type1>,<type2>,...)` (tuples). This parser is recursive for nested types.
    */
   static from(str: string): ABIType {
     if (str.endsWith('[]')) {

--- a/packages/abi/src/abi-type.ts
+++ b/packages/abi/src/abi-type.ts
@@ -82,6 +82,7 @@ export abstract class ABIType {
    * Encodes a value according to this ABI type.
    * @param value The value to encode
    * @returns The encoded bytes
+   * @throws {Error} If the value cannot be encoded as this type
    */
   abstract encode(value: ABIValue): Uint8Array
 
@@ -89,6 +90,7 @@ export abstract class ABIType {
    * Decodes bytes according to this ABI type.
    * @param bytes The bytes to decode
    * @returns The decoded value
+   * @throws {Error} If the bytes cannot be decoded as this type
    */
   abstract decode(bytes: Uint8Array): ABIValue
 
@@ -96,6 +98,7 @@ export abstract class ABIType {
    * Creates an ABI type from an ARC-4 type string.
    * @param str The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
    * @returns The corresponding ABI type
+   * @throws {Error} If the type string is malformed or unsupported
    */
   static from(str: string): ABIType {
     if (str.endsWith('[]')) {
@@ -172,6 +175,7 @@ export class ABIUintType extends ABIType {
   /**
    * Creates a new unsigned integer type.
    * @param bitSize The bit size (must be a multiple of 8, between 8 and 512)
+   * @throws {Error} If bitSize is not a multiple of 8 or not between 8 and 512
    */
   constructor(public readonly bitSize: number) {
     super()
@@ -227,6 +231,7 @@ export class ABIUfixedType extends ABIType {
    * Creates a new fixed-point type.
    * @param bitSize The bit size (must be a multiple of 8, between 8 and 512)
    * @param precision The decimal precision (must be between 1 and 160)
+   * @throws {Error} If bitSize or precision is out of valid range
    */
   constructor(
     public readonly bitSize: number,
@@ -463,6 +468,7 @@ export class ABITupleType extends ABIType {
   /**
    * Creates a new tuple type.
    * @param childTypes The types of the tuple elements
+   * @throws {Error} If the tuple has too many child types (exceeds 2^16-1)
    */
   constructor(public readonly childTypes: ABIType[]) {
     super()
@@ -600,6 +606,7 @@ export class ABIArrayStaticType extends ABIType {
    * Creates a new static array type.
    * @param childType The type of the array elements
    * @param length The fixed length of the array
+   * @throws {Error} If length is negative or exceeds 2^16-1
    */
   constructor(
     public readonly childType: ABIType,
@@ -800,6 +807,7 @@ export class ABIStructType extends ABIType {
    * @param structName The name of the struct
    * @param structs A record of struct definitions
    * @returns The struct type
+   * @throws {Error} If the struct name is not found in the struct definitions
    */
   static fromStruct(structName: string, structs: Record<string, StructField[]>): ABIStructType {
     const getStructFieldType = (structFieldType: string | StructField[]): ABIType | ABIStructField[] => {
@@ -986,6 +994,12 @@ function extractValues(abiTypes: ABIType[], bytes: Uint8Array): Uint8Array[] {
   return result
 }
 
+/**
+ * Parses the content of a tuple type string into individual type strings.
+ * @param content The content inside the tuple parentheses
+ * @returns An array of type strings
+ * @throws {Error} If the content has invalid comma placement or mismatched parentheses
+ */
 export function parseTupleContent(content: string): string[] {
   if (content === '') {
     return []

--- a/packages/algo25/src/index.ts
+++ b/packages/algo25/src/index.ts
@@ -47,6 +47,7 @@ function computeChecksum(seed: Uint8Array): string {
  * Each word in the mnemonic represents 11 bits of data, and the last 11 bits are reserved for the checksum.
  * @param seed - 32 bytes long seed
  * @returns 25 words mnemonic
+ * @throws {RangeError} If seed length is not 32 bytes
  */
 export function mnemonicFromSeed(seed: Uint8Array) {
   // Sanity length check
@@ -93,6 +94,9 @@ function toUint8Array(buffer11: number[]): Uint8Array {
  * of the passed words is not found in the words list.
  * @param mnemonic - 25 words mnemonic
  * @returns 32 bytes long seed
+ * @throws {Error} If a word is not in the wordlist
+ * @throws {Error} If the mnemonic has an incorrect checksum
+ * @throws {Error} If the mnemonic format is incorrect
  */
 export function seedFromMnemonic(mnemonic: string) {
   const words = mnemonic.split(' ')

--- a/packages/transact/src/logicsig.ts
+++ b/packages/transact/src/logicsig.ts
@@ -89,6 +89,13 @@ export class LogicSigAccount extends LogicSig {
   msig?: MultisigSignature
   lmsig?: MultisigSignature
 
+  /**
+   * Creates a LogicSigAccount from a LogicSigSignature.
+   * @param signature - The logic signature
+   * @param delegator - Optional delegator address
+   * @returns A LogicSigAccount instance
+   * @throws {Error} If delegator address doesn't match multisig address or if signature exists without delegator
+   */
   static fromSignature(signature: LogicSigSignature, delegator?: Address): LogicSigAccount {
     if (signature.lmsig || signature.msig) {
       const msigAddr = MultisigAccount.fromSignature((signature.lmsig || signature.msig)!).addr
@@ -151,6 +158,11 @@ export class LogicSigAccount extends LogicSig {
     }
   }
 
+  /**
+   * Signs the logic signature for delegation.
+   * @param delegator - The delegator with signing capability
+   * @throws {Error} If delegator address doesn't match expected address or signer returns invalid result
+   */
   async signForDelegation(delegator: AddressWithDelegatedLsigSigner) {
     const result = await delegator.lsigSigner(this)
 

--- a/packages/transact/src/logicsig.ts
+++ b/packages/transact/src/logicsig.ts
@@ -84,6 +84,15 @@ export class LogicSig implements Addressable {
   }
 }
 
+/**
+ * A logic signature account that can sign transactions using a TEAL program.
+ *
+ * @remarks
+ * Logic signatures can operate in two modes: contract mode (where the program itself is the authority)
+ * or delegated mode (where an account delegates signing authority to the program). In delegated mode,
+ * the delegator's signature authorizes the logic sig to sign on their behalf. Always verify the TEAL
+ * program logic before delegating, as the delegator is responsible for any transactions the program authorizes.
+ */
 export class LogicSigAccount extends LogicSig {
   sig?: Uint8Array
   msig?: MultisigSignature

--- a/packages/transact/src/multisig.ts
+++ b/packages/transact/src/multisig.ts
@@ -389,7 +389,14 @@ export interface MultisigMetadata {
   addrs: Array<Address>
 }
 
-/** Account wrapper that supports partial or full multisig signing. */
+/**
+ * Account wrapper that supports partial or full multisig signing.
+ *
+ * @remarks
+ * A multisig account requires M-of-N signatures to authorize transactions, where M is the threshold
+ * and N is the total number of participating addresses. The same address can appear multiple times
+ * in the participant list to implement weighted voting (each occurrence counts as one signature toward the threshold).
+ */
 export class MultisigAccount implements AddressWithTransactionSigner, AddressWithDelegatedLsigSigner {
   _params: MultisigMetadata
   _subSigners: (AddressWithTransactionSigner & AddressWithDelegatedLsigSigner)[]

--- a/packages/transact/src/multisig.ts
+++ b/packages/transact/src/multisig.ts
@@ -175,6 +175,10 @@ function createMultisigTransactionWithSignature(
  * takes a list of multisig transaction blobs, and merges them.
  * @param multisigTxnBlobs - a list of blobs representing encoded multisig txns
  * @returns typed array msg-pack encoded multisig txn
+ * @throws {Error} If fewer than two transactions are provided
+ * @throws {Error} If transaction IDs differ between transactions
+ * @throws {Error} If auth addresses differ between transactions
+ * @throws {Error} If multisig preimages or signatures are mismatched
  */
 function mergeMultisigTransactions(multisigTxnBlobs: SignedTransaction[]): SignedTransaction {
   if (multisigTxnBlobs.length < 2) {
@@ -258,6 +262,7 @@ function mergeMultisigTransactions(multisigTxnBlobs: SignedTransaction[]): Signe
  * @param signerAddr - address of the signer
  * @param signature - raw multisig signature
  * @returns an encoded, partially signed multisig transaction.
+ * @throws {Error} If signature length is incorrect
  */
 function partialSignWithMultisigSignature(
   transaction: Transaction,
@@ -310,6 +315,7 @@ function appendSignRawMultisigSignature(
  * @param version - multisig version
  * @param threshold - multisig threshold
  * @param pks - array of typed array public keys
+ * @throws {Error} If multisig parameters are invalid (version, threshold, or public keys)
  */
 function addressFromMultisigPreImg({
   version,

--- a/packages/transact/src/transactions/signed-transaction.ts
+++ b/packages/transact/src/transactions/signed-transaction.ts
@@ -152,6 +152,8 @@ export function decodeSignedTransactions(encodedSignedTransactions: Uint8Array[]
 
 /**
  * Validate a signed transaction structure
+ * @param signedTransaction - The signed transaction to validate
+ * @throws {Error} If multiple signature types are set or signature length is invalid
  */
 export function validateSignedTransaction(signedTransaction: SignedTransaction): void {
   validateTransaction(signedTransaction.txn)

--- a/src/amount.ts
+++ b/src/amount.ts
@@ -57,6 +57,7 @@ BigInt.prototype.algo = function () {
 
 /** Returns an amount of Algo using AlgoAmount
  * @param algos The amount of Algo
+ * @see {@link AlgoAmount}
  */
 export const algos = (algos: number | bigint) => {
   return AlgoAmount.Algo(algos)
@@ -71,6 +72,7 @@ export const algo = (algos: number | bigint) => {
 
 /** Returns an amount of µAlgo using AlgoAmount
  * @param microAlgos The amount of µAlgo
+ * @see {@link algos} for Algo denomination
  */
 export const microAlgos = (microAlgos: number | bigint) => {
   return AlgoAmount.MicroAlgo(microAlgos)

--- a/src/types/account-manager.ts
+++ b/src/types/account-manager.ts
@@ -591,6 +591,8 @@ export class AccountManager {
    * @returns
    * - The result of executing the dispensing transaction and the `amountFunded` if funds were needed.
    * - `undefined` if no funds were needed.
+   * @see {@link ensureFundedFromEnvironment} for environment-based dispenser
+   * @see {@link ensureFundedFromTestNetDispenserApi} for TestNet dispenser API
    */
   async ensureFunded(
     accountToFund: string | Address,

--- a/src/types/app-client.ts
+++ b/src/types/app-client.ts
@@ -426,8 +426,11 @@ function getConstantBlockOffset(program: Uint8Array) {
   return Math.max(bytecblockOffset ?? 0, intcblockOffset ?? 0)
 }
 
-/** ARC-56/ARC-32 application client that allows you to manage calls and
- * state for a specific deployed instance of an app (with a known app ID). */
+/**
+ * ARC-56/ARC-32 application client that allows you to manage calls and
+ * state for a specific deployed instance of an app (with a known app ID).
+ * @see {@link AppFactory} for creating and deploying apps
+ */
 export class AppClient {
   private _appId: bigint
   private _appAddress: Address

--- a/src/types/app-deployer.ts
+++ b/src/types/app-deployer.ts
@@ -142,6 +142,12 @@ export class AppDeployer {
    * **Note:** if there is a breaking state schema change to an existing app (and `onSchemaBreak` is set to `'replace'`) the existing app will be deleted and re-created.
    *
    * **Note:** if there is an update (different TEAL code) to an existing app (and `onUpdate` is set to `'replace'`) the existing app will be deleted and re-created.
+   *
+   * @remarks
+   * This method is idempotent: calling it multiple times with the same parameters will only create the app once,
+   * and subsequent calls will either do nothing (if unchanged) or update/replace as configured. App lookup is
+   * performed by creator address and app name, stored in the transaction note field during creation.
+   *
    * @param deployment The arguments to control the app deployment
    * @returns The result of the deployment
    * @example

--- a/src/types/app-factory.ts
+++ b/src/types/app-factory.ts
@@ -146,6 +146,8 @@ export type AppFactoryDeployParams = Expand<
  * ARC-56/ARC-32 app factory that, for a given app spec, allows you to create
  * and deploy one or more app instances and to create one or more app clients
  * to interact with those (or other) app instances.
+ * @see {@link AppClient} for interacting with deployed apps
+ * @see {@link AppDeployer} for lower-level deployment control
  */
 export class AppFactory {
   private _appSpec: Arc56Contract

--- a/src/types/composer.ts
+++ b/src/types/composer.ts
@@ -529,6 +529,7 @@ export class TransactionComposer {
    *   //  already specified, but here for completeness
    *   maxFee: (3000).microAlgo(),
    * })
+   * @see {@link AlgorandClient.send} for a simpler payment API
    */
   addPayment(params: PaymentParams): TransactionComposer {
     this.push({ data: params, type: 'pay' })

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,8 +3,9 @@ import { APP_PAGE_MAX_SIZE } from './types/app'
 /**
  * Converts a value which might be a number or a bigint into a number to be used with apis that don't support bigint.
  *
- * Throws an UnsafeConversionError if the conversion would result in an unsafe integer for the Number type
- * @param value
+ * @param value The value to convert
+ * @returns The value as a number
+ * @throws {UnsafeConversionError} If the conversion would result in an unsafe integer for the Number type
  */
 export const toNumber = (value: number | bigint) => {
   if (typeof value === 'number') return value


### PR DESCRIPTION
commit 1: Add @throws JSDoc tags to document error conditions across ABI, transaction, and mnemonic packages
commit 2: Add @remarks JSDoc tags to provide implementation context for key classes (MultisigAccount, LogicSigAccount, ABIType, AppDeployer)
commit 3: Add @see JSDoc tags to create cross-references between related functions and classes