### PR TITLE
Docs/typedoc include code examples

### DIFF
--- a/docs/api/Subpaths/abi/classes/ABIAddressType.md
+++ b/docs/api/Subpaths/abi/classes/ABIAddressType.md
@@ -6,7 +6,7 @@
 
 # Class: ABIAddressType
 
-Defined in: [packages/abi/src/abi-type.ts:285](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L285)
+Defined in: [packages/abi/src/abi-type.ts:288](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L288)
 
 An Algorand address ABI type.
 
@@ -62,7 +62,7 @@ The display name for this type
 
 > **get** **name**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:286](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L286)
+Defined in: [packages/abi/src/abi-type.ts:289](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L289)
 
 Returns the ARC-4 type name string representation.
 
@@ -82,7 +82,7 @@ The ARC-4 type string
 
 > **byteLen**(): `number`
 
-Defined in: [packages/abi/src/abi-type.ts:298](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L298)
+Defined in: [packages/abi/src/abi-type.ts:301](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L301)
 
 Gets the byte length of the encoded type for static types.
 
@@ -106,7 +106,7 @@ Error if the type is dynamic
 
 > **decode**(`bytes`): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:318](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L318)
+Defined in: [packages/abi/src/abi-type.ts:321](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L321)
 
 Decodes bytes according to this ABI type.
 
@@ -134,7 +134,7 @@ The decoded value
 
 > **encode**(`value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-type.ts:302](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L302)
+Defined in: [packages/abi/src/abi-type.ts:305](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L305)
 
 Encodes a value according to this ABI type.
 
@@ -162,7 +162,7 @@ The encoded bytes
 
 > **equals**(`other`): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:290](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L290)
+Defined in: [packages/abi/src/abi-type.ts:293](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L293)
 
 Checks if this ABI type is equal to another.
 
@@ -190,7 +190,7 @@ True if the types are equal, false otherwise
 
 > **isDynamic**(): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:294](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L294)
+Defined in: [packages/abi/src/abi-type.ts:297](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L297)
 
 Checks if this ABI type is dynamic (variable-length).
 
@@ -230,7 +230,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -247,6 +247,22 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 [`ABIType`](ABIType.md)
 
 The corresponding ABI type
+
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
 
 #### Inherited from
 

--- a/docs/api/Subpaths/abi/classes/ABIArrayDynamicType.md
+++ b/docs/api/Subpaths/abi/classes/ABIArrayDynamicType.md
@@ -6,7 +6,7 @@
 
 # Class: ABIArrayDynamicType
 
-Defined in: [packages/abi/src/abi-type.ts:668](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L668)
+Defined in: [packages/abi/src/abi-type.ts:671](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L671)
 
 A dynamic-length array ABI type.
 
@@ -24,7 +24,7 @@ A dynamic-length array ABI type.
 
 > **new ABIArrayDynamicType**(`childType`): `ABIArrayDynamicType`
 
-Defined in: [packages/abi/src/abi-type.ts:673](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L673)
+Defined in: [packages/abi/src/abi-type.ts:676](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L676)
 
 Creates a new dynamic array type.
 
@@ -50,7 +50,7 @@ The type of the array elements
 
 > `readonly` **childType**: [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:673](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L673)
+Defined in: [packages/abi/src/abi-type.ts:676](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L676)
 
 The type of the array elements
 
@@ -84,7 +84,7 @@ The display name for this type
 
 > **get** **name**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:677](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L677)
+Defined in: [packages/abi/src/abi-type.ts:680](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L680)
 
 Returns the ARC-4 type name string representation.
 
@@ -104,7 +104,7 @@ The ARC-4 type string
 
 > **byteLen**(): `number`
 
-Defined in: [packages/abi/src/abi-type.ts:689](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L689)
+Defined in: [packages/abi/src/abi-type.ts:692](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L692)
 
 Gets the byte length of the encoded type for static types.
 
@@ -128,7 +128,7 @@ Error if the type is dynamic
 
 > **decode**(`bytes`): `Uint8Array` \| [`ABIValue`](../type-aliases/ABIValue.md)[]
 
-Defined in: [packages/abi/src/abi-type.ts:712](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L712)
+Defined in: [packages/abi/src/abi-type.ts:715](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L715)
 
 Decodes bytes according to this ABI type.
 
@@ -156,7 +156,7 @@ The decoded value
 
 > **encode**(`value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-type.ts:702](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L702)
+Defined in: [packages/abi/src/abi-type.ts:705](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L705)
 
 Encodes a value according to this ABI type.
 
@@ -184,7 +184,7 @@ The encoded bytes
 
 > **equals**(`other`): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:681](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L681)
+Defined in: [packages/abi/src/abi-type.ts:684](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L684)
 
 Checks if this ABI type is equal to another.
 
@@ -212,7 +212,7 @@ True if the types are equal, false otherwise
 
 > **isDynamic**(): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:685](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L685)
+Defined in: [packages/abi/src/abi-type.ts:688](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L688)
 
 Checks if this ABI type is dynamic (variable-length).
 
@@ -232,7 +232,7 @@ True if the type is dynamic, false otherwise
 
 > **toABITupleType**(`length`): [`ABITupleType`](ABITupleType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:698](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L698)
+Defined in: [packages/abi/src/abi-type.ts:701](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L701)
 
 Converts this dynamic array type to an equivalent tuple type of a given length.
 
@@ -276,7 +276,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -293,6 +293,22 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 [`ABIType`](ABIType.md)
 
 The corresponding ABI type
+
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
 
 #### Inherited from
 

--- a/docs/api/Subpaths/abi/classes/ABIArrayStaticType.md
+++ b/docs/api/Subpaths/abi/classes/ABIArrayStaticType.md
@@ -6,7 +6,7 @@
 
 # Class: ABIArrayStaticType
 
-Defined in: [packages/abi/src/abi-type.ts:598](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L598)
+Defined in: [packages/abi/src/abi-type.ts:601](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L601)
 
 A static-length array ABI type.
 
@@ -24,7 +24,7 @@ A static-length array ABI type.
 
 > **new ABIArrayStaticType**(`childType`, `length`): `ABIArrayStaticType`
 
-Defined in: [packages/abi/src/abi-type.ts:604](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L604)
+Defined in: [packages/abi/src/abi-type.ts:607](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L607)
 
 Creates a new static array type.
 
@@ -56,7 +56,7 @@ The fixed length of the array
 
 > `readonly` **childType**: [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:605](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L605)
+Defined in: [packages/abi/src/abi-type.ts:608](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L608)
 
 The type of the array elements
 
@@ -66,7 +66,7 @@ The type of the array elements
 
 > `readonly` **length**: `number`
 
-Defined in: [packages/abi/src/abi-type.ts:606](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L606)
+Defined in: [packages/abi/src/abi-type.ts:609](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L609)
 
 The fixed length of the array
 
@@ -100,7 +100,7 @@ The display name for this type
 
 > **get** **name**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:614](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L614)
+Defined in: [packages/abi/src/abi-type.ts:617](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L617)
 
 Returns the ARC-4 type name string representation.
 
@@ -120,7 +120,7 @@ The ARC-4 type string
 
 > **byteLen**(): `number`
 
-Defined in: [packages/abi/src/abi-type.ts:626](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L626)
+Defined in: [packages/abi/src/abi-type.ts:629](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L629)
 
 Gets the byte length of the encoded type for static types.
 
@@ -144,7 +144,7 @@ Error if the type is dynamic
 
 > **decode**(`bytes`): `Uint8Array` \| [`ABIValue`](../type-aliases/ABIValue.md)[]
 
-Defined in: [packages/abi/src/abi-type.ts:652](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L652)
+Defined in: [packages/abi/src/abi-type.ts:655](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L655)
 
 Decodes bytes according to this ABI type.
 
@@ -172,7 +172,7 @@ The decoded value
 
 > **encode**(`value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-type.ts:641](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L641)
+Defined in: [packages/abi/src/abi-type.ts:644](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L644)
 
 Encodes a value according to this ABI type.
 
@@ -200,7 +200,7 @@ The encoded bytes
 
 > **equals**(`other`): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:618](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L618)
+Defined in: [packages/abi/src/abi-type.ts:621](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L621)
 
 Checks if this ABI type is equal to another.
 
@@ -228,7 +228,7 @@ True if the types are equal, false otherwise
 
 > **isDynamic**(): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:622](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L622)
+Defined in: [packages/abi/src/abi-type.ts:625](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L625)
 
 Checks if this ABI type is dynamic (variable-length).
 
@@ -248,7 +248,7 @@ True if the type is dynamic, false otherwise
 
 > **toABITupleType**(): [`ABITupleType`](ABITupleType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:637](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L637)
+Defined in: [packages/abi/src/abi-type.ts:640](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L640)
 
 Converts this static array type to an equivalent tuple type.
 
@@ -284,7 +284,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -301,6 +301,22 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 [`ABIType`](ABIType.md)
 
 The corresponding ABI type
+
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
 
 #### Inherited from
 

--- a/docs/api/Subpaths/abi/classes/ABIBoolType.md
+++ b/docs/api/Subpaths/abi/classes/ABIBoolType.md
@@ -6,7 +6,7 @@
 
 # Class: ABIBoolType
 
-Defined in: [packages/abi/src/abi-type.ts:326](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L326)
+Defined in: [packages/abi/src/abi-type.ts:329](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L329)
 
 A boolean ABI type.
 
@@ -62,7 +62,7 @@ The display name for this type
 
 > **get** **name**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:327](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L327)
+Defined in: [packages/abi/src/abi-type.ts:330](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L330)
 
 Returns the ARC-4 type name string representation.
 
@@ -82,7 +82,7 @@ The ARC-4 type string
 
 > **byteLen**(): `number`
 
-Defined in: [packages/abi/src/abi-type.ts:339](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L339)
+Defined in: [packages/abi/src/abi-type.ts:342](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L342)
 
 Gets the byte length of the encoded type for static types.
 
@@ -106,7 +106,7 @@ Error if the type is dynamic
 
 > **decode**(`bytes`): [`ABIValue`](../type-aliases/ABIValue.md)
 
-Defined in: [packages/abi/src/abi-type.ts:351](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L351)
+Defined in: [packages/abi/src/abi-type.ts:354](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L354)
 
 Decodes bytes according to this ABI type.
 
@@ -134,7 +134,7 @@ The decoded value
 
 > **encode**(`value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-type.ts:343](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L343)
+Defined in: [packages/abi/src/abi-type.ts:346](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L346)
 
 Encodes a value according to this ABI type.
 
@@ -162,7 +162,7 @@ The encoded bytes
 
 > **equals**(`other`): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:331](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L331)
+Defined in: [packages/abi/src/abi-type.ts:334](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L334)
 
 Checks if this ABI type is equal to another.
 
@@ -190,7 +190,7 @@ True if the types are equal, false otherwise
 
 > **isDynamic**(): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:335](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L335)
+Defined in: [packages/abi/src/abi-type.ts:338](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L338)
 
 Checks if this ABI type is dynamic (variable-length).
 
@@ -230,7 +230,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -247,6 +247,22 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 [`ABIType`](ABIType.md)
 
 The corresponding ABI type
+
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
 
 #### Inherited from
 

--- a/docs/api/Subpaths/abi/classes/ABIByteType.md
+++ b/docs/api/Subpaths/abi/classes/ABIByteType.md
@@ -6,7 +6,7 @@
 
 # Class: ABIByteType
 
-Defined in: [packages/abi/src/abi-type.ts:363](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L363)
+Defined in: [packages/abi/src/abi-type.ts:366](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L366)
 
 A single byte ABI type.
 
@@ -62,7 +62,7 @@ The display name for this type
 
 > **get** **name**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:364](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L364)
+Defined in: [packages/abi/src/abi-type.ts:367](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L367)
 
 Returns the ARC-4 type name string representation.
 
@@ -82,7 +82,7 @@ The ARC-4 type string
 
 > **byteLen**(): `number`
 
-Defined in: [packages/abi/src/abi-type.ts:376](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L376)
+Defined in: [packages/abi/src/abi-type.ts:379](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L379)
 
 Gets the byte length of the encoded type for static types.
 
@@ -106,7 +106,7 @@ Error if the type is dynamic
 
 > **decode**(`bytes`): [`ABIValue`](../type-aliases/ABIValue.md)
 
-Defined in: [packages/abi/src/abi-type.ts:392](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L392)
+Defined in: [packages/abi/src/abi-type.ts:395](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L395)
 
 Decodes bytes according to this ABI type.
 
@@ -134,7 +134,7 @@ The decoded value
 
 > **encode**(`value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-type.ts:380](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L380)
+Defined in: [packages/abi/src/abi-type.ts:383](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L383)
 
 Encodes a value according to this ABI type.
 
@@ -162,7 +162,7 @@ The encoded bytes
 
 > **equals**(`other`): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:368](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L368)
+Defined in: [packages/abi/src/abi-type.ts:371](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L371)
 
 Checks if this ABI type is equal to another.
 
@@ -190,7 +190,7 @@ True if the types are equal, false otherwise
 
 > **isDynamic**(): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:372](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L372)
+Defined in: [packages/abi/src/abi-type.ts:375](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L375)
 
 Checks if this ABI type is dynamic (variable-length).
 
@@ -230,7 +230,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -247,6 +247,22 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 [`ABIType`](ABIType.md)
 
 The corresponding ABI type
+
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
 
 #### Inherited from
 

--- a/docs/api/Subpaths/abi/classes/ABIMethod.md
+++ b/docs/api/Subpaths/abi/classes/ABIMethod.md
@@ -102,7 +102,7 @@ Defined in: [packages/abi/src/abi-method.ts:78](https://github.com/algorandfound
 
 > **getSelector**(): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-method.ts:117](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L117)
+Defined in: [packages/abi/src/abi-method.ts:123](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L123)
 
 Returns the method selector of this ABI method.
 
@@ -112,13 +112,27 @@ Returns the method selector of this ABI method.
 
 The 4-byte method selector
 
+#### Example
+
+```ts
+// Get the 4-byte method selector for ABI method calls
+const method = ABIMethod.fromSignature('add(uint64,uint64)uint64')
+const selector = method.getSelector()
+
+// Selector is the first 4 bytes of SHA-512/256 hash of the signature
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.spec.ts)
+
 ***
 
 ### getSignature()
 
 > **getSignature**(): `string`
 
-Defined in: [packages/abi/src/abi-method.ts:102](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L102)
+Defined in: [packages/abi/src/abi-method.ts:105](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L105)
 
 Returns the signature of this ABI method.
 
@@ -128,13 +142,25 @@ Returns the signature of this ABI method.
 
 The signature, e.g. `my_method(unit64,string)bytes`
 
+#### Example
+
+```ts
+// Get the full method signature string
+const method = ABIMethod.fromSignature('transfer(address,uint64)bool')
+const signature = method.getSignature()
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.spec.ts)
+
 ***
 
 ### fromSignature()
 
 > `static` **fromSignature**(`signature`): `ABIMethod`
 
-Defined in: [packages/abi/src/abi-method.ts:128](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L128)
+Defined in: [packages/abi/src/abi-method.ts:137](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L137)
 
 Returns the ABI method object for a given method signature.
 
@@ -152,3 +178,18 @@ e.g. `my_method(unit64,string)bytes`
 `ABIMethod`
 
 The `ABIMethod`
+
+#### Example
+
+```ts
+// Parse a method signature string into an ABIMethod object
+const method = ABIMethod.fromSignature('add(uint64,uint64)uint64')
+
+// Access method properties
+const name = method.name // 'add'
+const argCount = method.args.length // 2
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.spec.ts)

--- a/docs/api/Subpaths/abi/classes/ABIStringType.md
+++ b/docs/api/Subpaths/abi/classes/ABIStringType.md
@@ -6,7 +6,7 @@
 
 # Class: ABIStringType
 
-Defined in: [packages/abi/src/abi-type.ts:404](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L404)
+Defined in: [packages/abi/src/abi-type.ts:407](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L407)
 
 A dynamic-length string ABI type.
 
@@ -62,7 +62,7 @@ The display name for this type
 
 > **get** **name**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:405](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L405)
+Defined in: [packages/abi/src/abi-type.ts:408](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L408)
 
 Returns the ARC-4 type name string representation.
 
@@ -82,7 +82,7 @@ The ARC-4 type string
 
 > **byteLen**(): `number`
 
-Defined in: [packages/abi/src/abi-type.ts:417](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L417)
+Defined in: [packages/abi/src/abi-type.ts:420](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L420)
 
 Gets the byte length of the encoded type for static types.
 
@@ -106,7 +106,7 @@ Error if the type is dynamic
 
 > **decode**(`bytes`): [`ABIValue`](../type-aliases/ABIValue.md)
 
-Defined in: [packages/abi/src/abi-type.ts:439](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L439)
+Defined in: [packages/abi/src/abi-type.ts:442](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L442)
 
 Decodes bytes according to this ABI type.
 
@@ -134,7 +134,7 @@ The decoded value
 
 > **encode**(`value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-type.ts:421](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L421)
+Defined in: [packages/abi/src/abi-type.ts:424](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L424)
 
 Encodes a value according to this ABI type.
 
@@ -162,7 +162,7 @@ The encoded bytes
 
 > **equals**(`other`): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:409](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L409)
+Defined in: [packages/abi/src/abi-type.ts:412](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L412)
 
 Checks if this ABI type is equal to another.
 
@@ -190,7 +190,7 @@ True if the types are equal, false otherwise
 
 > **isDynamic**(): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:413](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L413)
+Defined in: [packages/abi/src/abi-type.ts:416](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L416)
 
 Checks if this ABI type is dynamic (variable-length).
 
@@ -230,7 +230,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -247,6 +247,22 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 [`ABIType`](ABIType.md)
 
 The corresponding ABI type
+
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
 
 #### Inherited from
 

--- a/docs/api/Subpaths/abi/classes/ABIStructType.md
+++ b/docs/api/Subpaths/abi/classes/ABIStructType.md
@@ -6,7 +6,7 @@
 
 # Class: ABIStructType
 
-Defined in: [packages/abi/src/abi-type.ts:730](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L730)
+Defined in: [packages/abi/src/abi-type.ts:733](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L733)
 
 A struct ABI type with named fields.
 
@@ -24,7 +24,7 @@ A struct ABI type with named fields.
 
 > **new ABIStructType**(`structName`, `structFields`): `ABIStructType`
 
-Defined in: [packages/abi/src/abi-type.ts:736](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L736)
+Defined in: [packages/abi/src/abi-type.ts:739](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L739)
 
 Creates a new struct type.
 
@@ -56,7 +56,7 @@ The fields of the struct
 
 > `readonly` **structFields**: [`ABIStructField`](../type-aliases/ABIStructField.md)[]
 
-Defined in: [packages/abi/src/abi-type.ts:738](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L738)
+Defined in: [packages/abi/src/abi-type.ts:741](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L741)
 
 The fields of the struct
 
@@ -66,7 +66,7 @@ The fields of the struct
 
 > `readonly` **structName**: `string`
 
-Defined in: [packages/abi/src/abi-type.ts:737](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L737)
+Defined in: [packages/abi/src/abi-type.ts:740](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L740)
 
 The name of the struct
 
@@ -78,7 +78,7 @@ The name of the struct
 
 > **get** **displayName**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:748](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L748)
+Defined in: [packages/abi/src/abi-type.ts:751](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L751)
 
 Returns a user-friendly display name for this type.
 
@@ -100,7 +100,7 @@ The display name for this type
 
 > **get** **name**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:743](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L743)
+Defined in: [packages/abi/src/abi-type.ts:746](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L746)
 
 Returns the ARC-4 type name string representation.
 
@@ -120,7 +120,7 @@ The ARC-4 type string
 
 > **byteLen**(): `number`
 
-Defined in: [packages/abi/src/abi-type.ts:774](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L774)
+Defined in: [packages/abi/src/abi-type.ts:777](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L777)
 
 Gets the byte length of the encoded type for static types.
 
@@ -144,7 +144,7 @@ Error if the type is dynamic
 
 > **decode**(`bytes`): `ABIStructValue`
 
-Defined in: [packages/abi/src/abi-type.ts:849](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L849)
+Defined in: [packages/abi/src/abi-type.ts:852](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L852)
 
 Decodes bytes according to this ABI type.
 
@@ -172,7 +172,7 @@ The decoded value
 
 > **encode**(`value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-type.ts:835](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L835)
+Defined in: [packages/abi/src/abi-type.ts:838](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L838)
 
 Encodes a value according to this ABI type.
 
@@ -200,7 +200,7 @@ The encoded bytes
 
 > **equals**(`other`): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:752](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L752)
+Defined in: [packages/abi/src/abi-type.ts:755](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L755)
 
 Checks if this ABI type is equal to another.
 
@@ -228,7 +228,7 @@ True if the types are equal, false otherwise
 
 > **isDynamic**(): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:769](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L769)
+Defined in: [packages/abi/src/abi-type.ts:772](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L772)
 
 Checks if this ABI type is dynamic (variable-length).
 
@@ -248,7 +248,7 @@ True if the type is dynamic, false otherwise
 
 > **toABITupleType**(): [`ABITupleType`](ABITupleType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:783](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L783)
+Defined in: [packages/abi/src/abi-type.ts:786](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L786)
 
 Converts this struct type to an equivalent tuple type.
 
@@ -284,7 +284,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -302,6 +302,22 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 
 The corresponding ABI type
 
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
+
 #### Inherited from
 
 [`ABIType`](ABIType.md).[`from`](ABIType.md#from)
@@ -312,7 +328,7 @@ The corresponding ABI type
 
 > `static` **fromStruct**(`structName`, `structs`): `ABIStructType`
 
-Defined in: [packages/abi/src/abi-type.ts:804](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L804)
+Defined in: [packages/abi/src/abi-type.ts:807](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L807)
 
 Creates an ABIStructType from struct name and struct definitions.
 

--- a/docs/api/Subpaths/abi/classes/ABITupleType.md
+++ b/docs/api/Subpaths/abi/classes/ABITupleType.md
@@ -6,7 +6,7 @@
 
 # Class: ABITupleType
 
-Defined in: [packages/abi/src/abi-type.ts:462](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L462)
+Defined in: [packages/abi/src/abi-type.ts:465](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L465)
 
 A tuple ABI type containing other ABI types.
 
@@ -24,7 +24,7 @@ A tuple ABI type containing other ABI types.
 
 > **new ABITupleType**(`childTypes`): `ABITupleType`
 
-Defined in: [packages/abi/src/abi-type.ts:467](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L467)
+Defined in: [packages/abi/src/abi-type.ts:470](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L470)
 
 Creates a new tuple type.
 
@@ -50,7 +50,7 @@ The types of the tuple elements
 
 > `readonly` **childTypes**: [`ABIType`](ABIType.md)[]
 
-Defined in: [packages/abi/src/abi-type.ts:467](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L467)
+Defined in: [packages/abi/src/abi-type.ts:470](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L470)
 
 The types of the tuple elements
 
@@ -84,7 +84,7 @@ The display name for this type
 
 > **get** **name**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:474](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L474)
+Defined in: [packages/abi/src/abi-type.ts:477](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L477)
 
 Returns the ARC-4 type name string representation.
 
@@ -104,7 +104,7 @@ The ARC-4 type string
 
 > **byteLen**(): `number`
 
-Defined in: [packages/abi/src/abi-type.ts:492](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L492)
+Defined in: [packages/abi/src/abi-type.ts:495](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L495)
 
 Gets the byte length of the encoded type for static types.
 
@@ -128,7 +128,7 @@ Error if the type is dynamic
 
 > **decode**(`bytes`): [`ABIValue`](../type-aliases/ABIValue.md)[]
 
-Defined in: [packages/abi/src/abi-type.ts:580](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L580)
+Defined in: [packages/abi/src/abi-type.ts:583](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L583)
 
 Decodes bytes according to this ABI type.
 
@@ -156,7 +156,7 @@ The decoded value
 
 > **encode**(`value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-type.ts:510](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L510)
+Defined in: [packages/abi/src/abi-type.ts:513](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L513)
 
 Encodes a value according to this ABI type.
 
@@ -184,7 +184,7 @@ The encoded bytes
 
 > **equals**(`other`): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:482](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L482)
+Defined in: [packages/abi/src/abi-type.ts:485](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L485)
 
 Checks if this ABI type is equal to another.
 
@@ -212,7 +212,7 @@ True if the types are equal, false otherwise
 
 > **isDynamic**(): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:488](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L488)
+Defined in: [packages/abi/src/abi-type.ts:491](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L491)
 
 Checks if this ABI type is dynamic (variable-length).
 
@@ -252,7 +252,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -269,6 +269,22 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 [`ABIType`](ABIType.md)
 
 The corresponding ABI type
+
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
 
 #### Inherited from
 

--- a/docs/api/Subpaths/abi/classes/ABIType.md
+++ b/docs/api/Subpaths/abi/classes/ABIType.md
@@ -205,7 +205,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): `ABIType`
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -222,3 +222,19 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 `ABIType`
 
 The corresponding ABI type
+
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)

--- a/docs/api/Subpaths/abi/classes/ABIUfixedType.md
+++ b/docs/api/Subpaths/abi/classes/ABIUfixedType.md
@@ -6,7 +6,7 @@
 
 # Class: ABIUfixedType
 
-Defined in: [packages/abi/src/abi-type.ts:225](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L225)
+Defined in: [packages/abi/src/abi-type.ts:228](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L228)
 
 A fixed-point number ABI type of a specific bit size and precision.
 
@@ -24,7 +24,7 @@ A fixed-point number ABI type of a specific bit size and precision.
 
 > **new ABIUfixedType**(`bitSize`, `precision`): `ABIUfixedType`
 
-Defined in: [packages/abi/src/abi-type.ts:231](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L231)
+Defined in: [packages/abi/src/abi-type.ts:234](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L234)
 
 Creates a new fixed-point type.
 
@@ -56,7 +56,7 @@ The decimal precision (must be between 1 and 160)
 
 > `readonly` **bitSize**: `number`
 
-Defined in: [packages/abi/src/abi-type.ts:232](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L232)
+Defined in: [packages/abi/src/abi-type.ts:235](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L235)
 
 The bit size (must be a multiple of 8, between 8 and 512)
 
@@ -66,7 +66,7 @@ The bit size (must be a multiple of 8, between 8 and 512)
 
 > `readonly` **precision**: `number`
 
-Defined in: [packages/abi/src/abi-type.ts:233](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L233)
+Defined in: [packages/abi/src/abi-type.ts:236](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L236)
 
 The decimal precision (must be between 1 and 160)
 
@@ -100,7 +100,7 @@ The display name for this type
 
 > **get** **name**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:244](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L244)
+Defined in: [packages/abi/src/abi-type.ts:247](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L247)
 
 Returns the ARC-4 type name string representation.
 
@@ -120,7 +120,7 @@ The ARC-4 type string
 
 > **byteLen**(): `number`
 
-Defined in: [packages/abi/src/abi-type.ts:256](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L256)
+Defined in: [packages/abi/src/abi-type.ts:259](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L259)
 
 Gets the byte length of the encoded type for static types.
 
@@ -144,7 +144,7 @@ Error if the type is dynamic
 
 > **decode**(`bytes`): [`ABIValue`](../type-aliases/ABIValue.md)
 
-Defined in: [packages/abi/src/abi-type.ts:273](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L273)
+Defined in: [packages/abi/src/abi-type.ts:276](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L276)
 
 Decodes bytes according to this ABI type.
 
@@ -172,7 +172,7 @@ The decoded value
 
 > **encode**(`value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-type.ts:260](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L260)
+Defined in: [packages/abi/src/abi-type.ts:263](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L263)
 
 Encodes a value according to this ABI type.
 
@@ -200,7 +200,7 @@ The encoded bytes
 
 > **equals**(`other`): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:248](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L248)
+Defined in: [packages/abi/src/abi-type.ts:251](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L251)
 
 Checks if this ABI type is equal to another.
 
@@ -228,7 +228,7 @@ True if the types are equal, false otherwise
 
 > **isDynamic**(): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:252](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L252)
+Defined in: [packages/abi/src/abi-type.ts:255](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L255)
 
 Checks if this ABI type is dynamic (variable-length).
 
@@ -268,7 +268,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -285,6 +285,22 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 [`ABIType`](ABIType.md)
 
 The corresponding ABI type
+
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
 
 #### Inherited from
 

--- a/docs/api/Subpaths/abi/classes/ABIUintType.md
+++ b/docs/api/Subpaths/abi/classes/ABIUintType.md
@@ -6,7 +6,7 @@
 
 # Class: ABIUintType
 
-Defined in: [packages/abi/src/abi-type.ts:171](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L171)
+Defined in: [packages/abi/src/abi-type.ts:174](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L174)
 
 An unsigned integer ABI type of a specific bit size.
 
@@ -24,7 +24,7 @@ An unsigned integer ABI type of a specific bit size.
 
 > **new ABIUintType**(`bitSize`): `ABIUintType`
 
-Defined in: [packages/abi/src/abi-type.ts:176](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L176)
+Defined in: [packages/abi/src/abi-type.ts:179](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L179)
 
 Creates a new unsigned integer type.
 
@@ -50,7 +50,7 @@ The bit size (must be a multiple of 8, between 8 and 512)
 
 > `readonly` **bitSize**: `number`
 
-Defined in: [packages/abi/src/abi-type.ts:176](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L176)
+Defined in: [packages/abi/src/abi-type.ts:179](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L179)
 
 The bit size (must be a multiple of 8, between 8 and 512)
 
@@ -84,7 +84,7 @@ The display name for this type
 
 > **get** **name**(): `string`
 
-Defined in: [packages/abi/src/abi-type.ts:183](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L183)
+Defined in: [packages/abi/src/abi-type.ts:186](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L186)
 
 Returns the ARC-4 type name string representation.
 
@@ -104,7 +104,7 @@ The ARC-4 type string
 
 > **byteLen**(): `number`
 
-Defined in: [packages/abi/src/abi-type.ts:195](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L195)
+Defined in: [packages/abi/src/abi-type.ts:198](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L198)
 
 Gets the byte length of the encoded type for static types.
 
@@ -128,7 +128,7 @@ Error if the type is dynamic
 
 > **decode**(`bytes`): [`ABIValue`](../type-aliases/ABIValue.md)
 
-Defined in: [packages/abi/src/abi-type.ts:213](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L213)
+Defined in: [packages/abi/src/abi-type.ts:216](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L216)
 
 Decodes bytes according to this ABI type.
 
@@ -156,7 +156,7 @@ The decoded value
 
 > **encode**(`value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-type.ts:199](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L199)
+Defined in: [packages/abi/src/abi-type.ts:202](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L202)
 
 Encodes a value according to this ABI type.
 
@@ -184,7 +184,7 @@ The encoded bytes
 
 > **equals**(`other`): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:187](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L187)
+Defined in: [packages/abi/src/abi-type.ts:190](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L190)
 
 Checks if this ABI type is equal to another.
 
@@ -212,7 +212,7 @@ True if the types are equal, false otherwise
 
 > **isDynamic**(): `boolean`
 
-Defined in: [packages/abi/src/abi-type.ts:191](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L191)
+Defined in: [packages/abi/src/abi-type.ts:194](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L194)
 
 Checks if this ABI type is dynamic (variable-length).
 
@@ -252,7 +252,7 @@ The ARC-4 type string
 
 > `static` **from**(`str`): [`ABIType`](ABIType.md)
 
-Defined in: [packages/abi/src/abi-type.ts:100](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L100)
+Defined in: [packages/abi/src/abi-type.ts:103](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L103)
 
 Creates an ABI type from an ARC-4 type string.
 
@@ -269,6 +269,22 @@ The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
 [`ABIType`](ABIType.md)
 
 The corresponding ABI type
+
+#### Example
+
+```ts
+// Parse ABI type strings into type objects
+const uint64Type = ABIType.from('uint64')
+const tupleType = ABIType.from('(uint64,string,bool)')
+const arrayType = ABIType.from('uint32[]')
+
+// Use the type name property
+const typeName = uint64Type.name // 'uint64'
+```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
 
 #### Inherited from
 

--- a/docs/api/Subpaths/abi/functions/arc56MethodToABIMethod.md
+++ b/docs/api/Subpaths/abi/functions/arc56MethodToABIMethod.md
@@ -8,7 +8,7 @@
 
 > **arc56MethodToABIMethod**(`method`, `appSpec`): [`ABIMethod`](../classes/ABIMethod.md)
 
-Defined in: [packages/abi/src/abi-method.ts:205](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L205)
+Defined in: [packages/abi/src/abi-method.ts:214](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L214)
 
 ## Parameters
 

--- a/docs/api/Subpaths/abi/functions/argTypeIsAbiType.md
+++ b/docs/api/Subpaths/abi/functions/argTypeIsAbiType.md
@@ -8,7 +8,7 @@
 
 > **argTypeIsAbiType**(`type`): `type is ABIType`
 
-Defined in: [packages/abi/src/abi-method.ts:285](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L285)
+Defined in: [packages/abi/src/abi-method.ts:294](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L294)
 
 ## Parameters
 

--- a/docs/api/Subpaths/abi/functions/argTypeIsReference.md
+++ b/docs/api/Subpaths/abi/functions/argTypeIsReference.md
@@ -8,7 +8,7 @@
 
 > **argTypeIsReference**(`type`): `type is ABIReferenceType`
 
-Defined in: [packages/abi/src/abi-method.ts:278](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L278)
+Defined in: [packages/abi/src/abi-method.ts:287](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L287)
 
 ## Parameters
 

--- a/docs/api/Subpaths/abi/functions/argTypeIsTransaction.md
+++ b/docs/api/Subpaths/abi/functions/argTypeIsTransaction.md
@@ -8,7 +8,7 @@
 
 > **argTypeIsTransaction**(`type`): `type is ABITransactionType`
 
-Defined in: [packages/abi/src/abi-method.ts:265](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L265)
+Defined in: [packages/abi/src/abi-method.ts:274](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L274)
 
 ## Parameters
 

--- a/docs/api/Subpaths/abi/functions/decodeAVMValue.md
+++ b/docs/api/Subpaths/abi/functions/decodeAVMValue.md
@@ -8,7 +8,7 @@
 
 > **decodeAVMValue**(`avmType`, `bytes`): [`ABIValue`](../type-aliases/ABIValue.md)
 
-Defined in: [packages/abi/src/abi-method.ts:295](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L295)
+Defined in: [packages/abi/src/abi-method.ts:304](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L304)
 
 ## Parameters
 

--- a/docs/api/Subpaths/abi/functions/getABIDecodedValue.md
+++ b/docs/api/Subpaths/abi/functions/getABIDecodedValue.md
@@ -8,7 +8,7 @@
 
 > **getABIDecodedValue**(`type`, `bytes`): [`ABIValue`](../type-aliases/ABIValue.md)
 
-Defined in: [packages/abi/src/abi-method.ts:324](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L324)
+Defined in: [packages/abi/src/abi-method.ts:333](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L333)
 
 ## Parameters
 

--- a/docs/api/Subpaths/abi/functions/getABIEncodedValue.md
+++ b/docs/api/Subpaths/abi/functions/getABIEncodedValue.md
@@ -8,7 +8,7 @@
 
 > **getABIEncodedValue**(`type`, `value`): `Uint8Array`
 
-Defined in: [packages/abi/src/abi-method.ts:335](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L335)
+Defined in: [packages/abi/src/abi-method.ts:344](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L344)
 
 ## Parameters
 

--- a/docs/api/Subpaths/abi/functions/getABIMethod.md
+++ b/docs/api/Subpaths/abi/functions/getABIMethod.md
@@ -8,7 +8,7 @@
 
 > **getABIMethod**(`methodNameOrSignature`, `appSpec`): [`ABIMethod`](../classes/ABIMethod.md)
 
-Defined in: [packages/abi/src/abi-method.ts:184](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L184)
+Defined in: [packages/abi/src/abi-method.ts:193](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L193)
 
 Returns the ABI method object for a given method name or signature and ARC-56 app spec.
 

--- a/docs/api/Subpaths/abi/functions/isAVMType.md
+++ b/docs/api/Subpaths/abi/functions/isAVMType.md
@@ -8,7 +8,7 @@
 
 > **isAVMType**(`type`): `type is AVMType`
 
-Defined in: [packages/abi/src/abi-method.ts:320](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L320)
+Defined in: [packages/abi/src/abi-method.ts:329](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.ts#L329)
 
 ## Parameters
 

--- a/docs/api/Subpaths/abi/functions/parseTupleContent.md
+++ b/docs/api/Subpaths/abi/functions/parseTupleContent.md
@@ -8,7 +8,7 @@
 
 > **parseTupleContent**(`content`): `string`[]
 
-Defined in: [packages/abi/src/abi-type.ts:989](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L989)
+Defined in: [packages/abi/src/abi-type.ts:992](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.ts#L992)
 
 ## Parameters
 

--- a/docs/api/Subpaths/transact/classes/MultisigAccount.md
+++ b/docs/api/Subpaths/transact/classes/MultisigAccount.md
@@ -6,9 +6,28 @@
 
 # Class: MultisigAccount
 
-Defined in: [packages/transact/src/multisig.ts:387](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L387)
+Defined in: [packages/transact/src/multisig.ts:392](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L392)
 
 Account wrapper that supports partial or full multisig signing.
+
+## Example
+
+```ts
+// Create a multisig account with 2-of-2 threshold
+const addrs = [
+  'RIMARGKZU46OZ77OLPDHHPUJ7YBSHRTCYMQUC64KZCCMESQAFQMYU6SL2Q',
+  'ALGOC4J2BCZ33TCKSSAMV5GAXQBMV3HDCHDBSPRBZRNSR7BM2FFDZRFGXA',
+].map((s) => Address.fromString(s))
+
+const msigAccount = new MultisigAccount({ version: 1, threshold: 2, addrs }, [])
+
+// Create an empty multisig signature structure
+const multisig = msigAccount.createMultisigSignature()
+```
+
+## See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.spec.ts)
 
 ## Implements
 
@@ -21,7 +40,7 @@ Account wrapper that supports partial or full multisig signing.
 
 > **new MultisigAccount**(`multisigParams`, `subSigners`): `MultisigAccount`
 
-Defined in: [packages/transact/src/multisig.ts:428](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L428)
+Defined in: [packages/transact/src/multisig.ts:433](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L433)
 
 #### Parameters
 
@@ -43,7 +62,7 @@ Defined in: [packages/transact/src/multisig.ts:428](https://github.com/algorandf
 
 > **\_addr**: [`Address`](../../../algokit-utils/classes/Address.md)
 
-Defined in: [packages/transact/src/multisig.ts:390](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L390)
+Defined in: [packages/transact/src/multisig.ts:395](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L395)
 
 ***
 
@@ -51,7 +70,7 @@ Defined in: [packages/transact/src/multisig.ts:390](https://github.com/algorandf
 
 > **\_lsigSigner**: [`DelegatedLsigSigner`](../type-aliases/DelegatedLsigSigner.md)
 
-Defined in: [packages/transact/src/multisig.ts:392](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L392)
+Defined in: [packages/transact/src/multisig.ts:397](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L397)
 
 ***
 
@@ -59,7 +78,7 @@ Defined in: [packages/transact/src/multisig.ts:392](https://github.com/algorandf
 
 > **\_params**: [`MultisigMetadata`](../interfaces/MultisigMetadata.md)
 
-Defined in: [packages/transact/src/multisig.ts:388](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L388)
+Defined in: [packages/transact/src/multisig.ts:393](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L393)
 
 ***
 
@@ -67,7 +86,7 @@ Defined in: [packages/transact/src/multisig.ts:388](https://github.com/algorandf
 
 > **\_signer**: [`TransactionSigner`](../type-aliases/TransactionSigner.md)
 
-Defined in: [packages/transact/src/multisig.ts:391](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L391)
+Defined in: [packages/transact/src/multisig.ts:396](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L396)
 
 ***
 
@@ -75,7 +94,7 @@ Defined in: [packages/transact/src/multisig.ts:391](https://github.com/algorandf
 
 > **\_subSigners**: [`AddressWithTransactionSigner`](../interfaces/AddressWithTransactionSigner.md) & [`AddressWithDelegatedLsigSigner`](../interfaces/AddressWithDelegatedLsigSigner.md)[]
 
-Defined in: [packages/transact/src/multisig.ts:389](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L389)
+Defined in: [packages/transact/src/multisig.ts:394](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L394)
 
 ## Accessors
 
@@ -85,7 +104,7 @@ Defined in: [packages/transact/src/multisig.ts:389](https://github.com/algorandf
 
 > **get** **addr**(): `Readonly`\<[`Address`](../../../algokit-utils/classes/Address.md)\>
 
-Defined in: [packages/transact/src/multisig.ts:405](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L405)
+Defined in: [packages/transact/src/multisig.ts:410](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L410)
 
 The address of the multisig account
 
@@ -105,7 +124,7 @@ The address of the multisig account
 
 > **get** **lsigSigner**(): [`DelegatedLsigSigner`](../type-aliases/DelegatedLsigSigner.md)
 
-Defined in: [packages/transact/src/multisig.ts:414](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L414)
+Defined in: [packages/transact/src/multisig.ts:419](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L419)
 
 ##### Returns
 
@@ -123,7 +142,7 @@ Defined in: [packages/transact/src/multisig.ts:414](https://github.com/algorandf
 
 > **get** **params**(): `Readonly`\<[`MultisigMetadata`](../interfaces/MultisigMetadata.md)\>
 
-Defined in: [packages/transact/src/multisig.ts:395](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L395)
+Defined in: [packages/transact/src/multisig.ts:400](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L400)
 
 The parameters for the multisig account
 
@@ -139,7 +158,7 @@ The parameters for the multisig account
 
 > **get** **signer**(): [`TransactionSigner`](../type-aliases/TransactionSigner.md)
 
-Defined in: [packages/transact/src/multisig.ts:410](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L410)
+Defined in: [packages/transact/src/multisig.ts:415](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L415)
 
 The transaction signer for the multisig account
 
@@ -159,7 +178,7 @@ The transaction signer for the multisig account
 
 > **get** **subSigners**(): [`AddressWithTransactionSigner`](../interfaces/AddressWithTransactionSigner.md) & [`AddressWithDelegatedLsigSigner`](../interfaces/AddressWithDelegatedLsigSigner.md)[]
 
-Defined in: [packages/transact/src/multisig.ts:400](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L400)
+Defined in: [packages/transact/src/multisig.ts:405](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L405)
 
 The list of accounts that are present to sign transactions or lsigs
 
@@ -173,7 +192,7 @@ The list of accounts that are present to sign transactions or lsigs
 
 > **applySignature**(`msigSignature`, `pubkey`, `signature`): [`MultisigSignature`](../type-aliases/MultisigSignature.md)
 
-Defined in: [packages/transact/src/multisig.ts:507](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L507)
+Defined in: [packages/transact/src/multisig.ts:512](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L512)
 
 #### Parameters
 
@@ -199,7 +218,7 @@ Defined in: [packages/transact/src/multisig.ts:507](https://github.com/algorandf
 
 > **applySignatureToTxn**(`txn`, `pubkey`, `signature`): `void`
 
-Defined in: [packages/transact/src/multisig.ts:498](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L498)
+Defined in: [packages/transact/src/multisig.ts:503](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L503)
 
 #### Parameters
 
@@ -225,7 +244,7 @@ Defined in: [packages/transact/src/multisig.ts:498](https://github.com/algorandf
 
 > **createMultisigSignature**(): [`MultisigSignature`](../type-aliases/MultisigSignature.md)
 
-Defined in: [packages/transact/src/multisig.ts:484](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L484)
+Defined in: [packages/transact/src/multisig.ts:489](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L489)
 
 #### Returns
 
@@ -237,7 +256,7 @@ Defined in: [packages/transact/src/multisig.ts:484](https://github.com/algorandf
 
 > **createMultisigTransaction**(`txn`): [`SignedTransaction`](../type-aliases/SignedTransaction.md)
 
-Defined in: [packages/transact/src/multisig.ts:480](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L480)
+Defined in: [packages/transact/src/multisig.ts:485](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L485)
 
 #### Parameters
 
@@ -255,7 +274,7 @@ Defined in: [packages/transact/src/multisig.ts:480](https://github.com/algorandf
 
 > `static` **fromSignature**(`signature`): `MultisigAccount`
 
-Defined in: [packages/transact/src/multisig.ts:418](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L418)
+Defined in: [packages/transact/src/multisig.ts:423](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.ts#L423)
 
 #### Parameters
 

--- a/docs/api/Subpaths/transact/functions/generateAddressWithSigners.md
+++ b/docs/api/Subpaths/transact/functions/generateAddressWithSigners.md
@@ -8,7 +8,7 @@
 
 > **generateAddressWithSigners**(`args`): `object`
 
-Defined in: [packages/transact/src/signer.ts:46](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/signer.ts#L46)
+Defined in: [packages/transact/src/signer.ts:49](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/signer.ts#L49)
 
 Generate type-safe domain-separated signer callbacks given an ed25519 pubkey and a signing callback
 
@@ -61,3 +61,29 @@ An object containing the sending address and various signer functions
 ### signer
 
 > **signer**: [`TransactionSigner`](../type-aliases/TransactionSigner.md)
+
+## Example
+
+```ts
+// Generate signers from an ed25519 keypair
+const keypair = nacl.sign.keyPair()
+
+// Create a raw signing callback
+const rawSigner = async (bytesToSign: Uint8Array): Promise<Uint8Array> => {
+  return nacl.sign.detached(bytesToSign, keypair.secretKey)
+}
+
+// Generate all signer types from the keypair
+const addressWithSigners = generateAddressWithSigners({
+  ed25519Pubkey: keypair.publicKey,
+  rawEd25519Signer: rawSigner,
+})
+
+// Access the address and various signers
+const address = addressWithSigners.addr
+const transactionSigner = addressWithSigners.signer
+```
+
+## See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/signer.spec.ts)

--- a/docs/api/Subpaths/transact/functions/makeEmptyTransactionSigner.md
+++ b/docs/api/Subpaths/transact/functions/makeEmptyTransactionSigner.md
@@ -8,7 +8,7 @@
 
 > **makeEmptyTransactionSigner**(): [`TransactionSigner`](../type-aliases/TransactionSigner.md)
 
-Defined in: [packages/transact/src/signer.ts:102](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/signer.ts#L102)
+Defined in: [packages/transact/src/signer.ts:105](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/signer.ts#L105)
 
 Create a makeEmptyTransactionSigner that does not specify any signer or
 signing capabilities. This should only be used to simulate transactions.

--- a/docs/api/algokit-utils/functions/algo.md
+++ b/docs/api/algokit-utils/functions/algo.md
@@ -8,7 +8,7 @@
 
 > **algo**(`algos`): [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
 
-Defined in: [src/amount.ts:68](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L68)
+Defined in: [src/amount.ts:74](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L74)
 
 Returns an amount of Algo using AlgoAmount
 
@@ -23,3 +23,17 @@ The amount of Algo
 ## Returns
 
 [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
+
+## Example
+
+```ts
+// Create an AlgoAmount using the Number.prototype extension
+const amount = (100).algo()
+
+// Access the value in Algo
+const algoValue = amount.algo // 100
+```
+
+## See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/amount.spec.ts)

--- a/docs/api/algokit-utils/functions/algos.md
+++ b/docs/api/algokit-utils/functions/algos.md
@@ -8,7 +8,7 @@
 
 > **algos**(`algos`): [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
 
-Defined in: [src/amount.ts:61](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L61)
+Defined in: [src/amount.ts:64](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L64)
 
 Returns an amount of Algo using AlgoAmount
 
@@ -23,3 +23,20 @@ The amount of Algo
 ## Returns
 
 [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
+
+## Example
+
+```ts
+// Create an amount of 100 Algo
+const amount = algos(100)
+
+// Access the value in microAlgo (100 * 1_000_000)
+const microAlgoValue = amount.microAlgo // 100_000_000n
+
+// Access the value in Algo
+const algoValue = amount.algo // 100
+```
+
+## See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/amount.spec.ts)

--- a/docs/api/algokit-utils/functions/encodeLease.md
+++ b/docs/api/algokit-utils/functions/encodeLease.md
@@ -31,11 +31,3 @@ the transaction lease ready for inclusion in a transaction or `undefined` if the
 if the length of the data is > 32 bytes or empty
 
 ## Examples
-
-```ts
-algokit.encodeLease('UNIQUE_ID')
-```
-
-```ts
-algokit.encodeLease(new Uint8Array([1, 2, 3]))
-```

--- a/docs/api/algokit-utils/functions/microAlgo.md
+++ b/docs/api/algokit-utils/functions/microAlgo.md
@@ -8,7 +8,7 @@
 
 > **microAlgo**(`microAlgos`): [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
 
-Defined in: [src/amount.ts:82](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L82)
+Defined in: [src/amount.ts:94](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L94)
 
 Returns an amount of µAlgo using AlgoAmount
 
@@ -23,3 +23,17 @@ The amount of µAlgo
 ## Returns
 
 [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
+
+## Example
+
+```ts
+// Create an AlgoAmount using the Number.prototype extension
+const amount = (100).microAlgo()
+
+// Access the value in microAlgo
+const microAlgoValue = amount.microAlgo // 100n
+```
+
+## See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/amount.spec.ts)

--- a/docs/api/algokit-utils/functions/microAlgos.md
+++ b/docs/api/algokit-utils/functions/microAlgos.md
@@ -8,7 +8,7 @@
 
 > **microAlgos**(`microAlgos`): [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
 
-Defined in: [src/amount.ts:75](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L75)
+Defined in: [src/amount.ts:84](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L84)
 
 Returns an amount of µAlgo using AlgoAmount
 
@@ -23,3 +23,20 @@ The amount of µAlgo
 ## Returns
 
 [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
+
+## Example
+
+```ts
+// Create an amount of 100 microAlgo
+const amount = microAlgos(100)
+
+// Access the value in microAlgo
+const microAlgoValue = amount.microAlgo // 100n
+
+// Access the value in Algo
+const algoValue = amount.algo // 0.0001
+```
+
+## See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/amount.spec.ts)

--- a/docs/api/algokit-utils/functions/transactionFees.md
+++ b/docs/api/algokit-utils/functions/transactionFees.md
@@ -8,7 +8,7 @@
 
 > **transactionFees**(`numberOfTransactions`): [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
 
-Defined in: [src/amount.ts:89](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L89)
+Defined in: [src/amount.ts:104](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L104)
 
 Returns an amount of µAlgo to cover standard fees for the given number of transactions using AlgoAmount
 
@@ -23,3 +23,21 @@ The of standard transaction fees to return the amount of Algo
 ## Returns
 
 [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
+
+## Example
+
+```ts
+// Get the fee amount for a single transaction (1000 microAlgo)
+const singleFee = transactionFees(1)
+
+// Get the fee amount for multiple transactions
+const multipleFees = transactionFees(10)
+
+// Access the values
+const singleFeeValue = singleFee.microAlgo // 1_000n
+const multipleFeeValue = multipleFees.microAlgo // 10_000n
+```
+
+## See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/amount.spec.ts)

--- a/docs/api/algokit-utils/variables/ALGORAND_MIN_TX_FEE.md
+++ b/docs/api/algokit-utils/variables/ALGORAND_MIN_TX_FEE.md
@@ -8,4 +8,4 @@
 
 > `const` **ALGORAND\_MIN\_TX\_FEE**: [`AlgoAmount`](../../types/amount/classes/AlgoAmount.md)
 
-Defined in: [src/amount.ts:93](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L93)
+Defined in: [src/amount.ts:108](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/amount.ts#L108)

--- a/docs/api/types/algorand-client-transaction-sender/classes/AlgorandClientTransactionSender.md
+++ b/docs/api/types/algorand-client-transaction-sender/classes/AlgorandClientTransactionSender.md
@@ -56,7 +56,7 @@ const transactionSender = new AlgorandClientTransactionSender(() => new Transact
 
 > **appCall**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `return?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md); `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:741](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L741)
+Defined in: [src/types/algorand-client-transaction-sender.ts:735](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L735)
 
 Call a smart contract.
 
@@ -118,7 +118,7 @@ await algorand.send.appCall({
 
 > **appCallMethodCall**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `return?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md); `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:989](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L989)
+Defined in: [src/types/algorand-client-transaction-sender.ts:983](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L983)
 
 Call a smart contract via an ABI method.
 
@@ -192,7 +192,7 @@ await algorand.send.appCallMethodCall({
 
 > **appCreate**: (`params`) => `Promise`\<\{ `appAddress`: [`Address`](../../../algokit-utils/classes/Address.md); `appId`: `bigint`; `compiledApproval?`: [`CompiledTeal`](../../app/interfaces/CompiledTeal.md); `compiledClear?`: [`CompiledTeal`](../../app/interfaces/CompiledTeal.md); `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `return?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md); `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:598](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L598)
+Defined in: [src/types/algorand-client-transaction-sender.ts:592](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L592)
 
 Create a smart contract.
 
@@ -264,7 +264,7 @@ await algorand.send.appCreate({
 
 > **appCreateMethodCall**: (`params`) => `Promise`\<\{ `appAddress`: [`Address`](../../../algokit-utils/classes/Address.md); `appId`: `bigint`; `compiledApproval?`: [`CompiledTeal`](../../app/interfaces/CompiledTeal.md); `compiledClear?`: [`CompiledTeal`](../../app/interfaces/CompiledTeal.md); `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `return?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md); `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:810](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L810)
+Defined in: [src/types/algorand-client-transaction-sender.ts:804](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L804)
 
 Create a smart contract via an ABI method.
 
@@ -348,7 +348,7 @@ await algorand.send.appCreateMethodCall({
 
 > **appDelete**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `return?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md); `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:694](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L694)
+Defined in: [src/types/algorand-client-transaction-sender.ts:688](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L688)
 
 Delete a smart contract.
 
@@ -410,7 +410,7 @@ await algorand.send.appDelete({
 
 > **appDeleteMethodCall**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `return?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md); `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:930](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L930)
+Defined in: [src/types/algorand-client-transaction-sender.ts:924](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L924)
 
 Delete a smart contract via an ABI method.
 
@@ -484,7 +484,7 @@ await algorand.send.appDeleteMethodCall({
 
 > **appUpdate**: (`params`) => `Promise`\<\{ `compiledApproval?`: [`CompiledTeal`](../../app/interfaces/CompiledTeal.md); `compiledClear?`: [`CompiledTeal`](../../app/interfaces/CompiledTeal.md); `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `return?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md); `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:647](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L647)
+Defined in: [src/types/algorand-client-transaction-sender.ts:641](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L641)
 
 Update a smart contract.
 
@@ -548,7 +548,7 @@ await algorand.send.appUpdate({
 
 > **appUpdateMethodCall**: (`params`) => `Promise`\<\{ `compiledApproval?`: [`CompiledTeal`](../../app/interfaces/CompiledTeal.md); `compiledClear?`: [`CompiledTeal`](../../app/interfaces/CompiledTeal.md); `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `return?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md); `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:871](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L871)
+Defined in: [src/types/algorand-client-transaction-sender.ts:865](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L865)
 
 Update a smart contract via an ABI method.
 
@@ -624,7 +624,7 @@ await algorand.send.appUpdateMethodCall({
 
 > **assetConfig**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:306](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L306)
+Defined in: [src/types/algorand-client-transaction-sender.ts:300](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L300)
 
 Configure an existing Algorand Standard Asset.
 
@@ -685,7 +685,7 @@ await algorand.send.assetConfig({
 
 > **assetDestroy**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:386](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L386)
+Defined in: [src/types/algorand-client-transaction-sender.ts:380](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L380)
 
 Destroys an Algorand Standard Asset.
 
@@ -742,7 +742,7 @@ await algorand.send.assetDestroy({
 
 > **assetFreeze**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:345](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L345)
+Defined in: [src/types/algorand-client-transaction-sender.ts:339](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L339)
 
 Freeze or unfreeze an Algorand Standard Asset for an account.
 
@@ -797,7 +797,7 @@ await algorand.send.assetFreeze({
 
 > **assetOptIn**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:466](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L466)
+Defined in: [src/types/algorand-client-transaction-sender.ts:460](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L460)
 
 Opt an account into an Algorand Standard Asset.
 
@@ -850,7 +850,7 @@ await algorand.send.assetOptIn({
 
 > **assetTransfer**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:428](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L428)
+Defined in: [src/types/algorand-client-transaction-sender.ts:422](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L422)
 
 Transfer an Algorand Standard Asset.
 
@@ -908,7 +908,7 @@ await algorand.send.assetTransfer({
 
 > **offlineKeyRegistration**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:1068](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L1068)
+Defined in: [src/types/algorand-client-transaction-sender.ts:1062](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L1062)
 
 Register an offline key.
 
@@ -958,7 +958,7 @@ const result = await algorand.send.offlineKeyRegistration({
 
 > **onlineKeyRegistration**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:1035](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L1035)
+Defined in: [src/types/algorand-client-transaction-sender.ts:1029](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L1029)
 
 Register an online key.
 
@@ -1020,7 +1020,7 @@ const result = await algorand.send.onlineKeyRegistration({
 
 > **payment**: (`params`) => `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:206](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L206)
+Defined in: [src/types/algorand-client-transaction-sender.ts:201](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L201)
 
 Send a payment transaction to transfer Algo between accounts.
 
@@ -1040,12 +1040,9 @@ The result of the payment transaction and the transaction that was sent
 
 #### Examples
 
-```typescript
-const result = await algorand.send.payment({
- sender: 'SENDERADDRESS',
- receiver: 'RECEIVERADDRESS',
- amount: (4).algo(),
-})
+```ts
+// Send a payment transaction
+await algorand.send.payment({ sender: alice, receiver: bob, amount: AlgoAmount.MicroAlgo(1) })
 ```
 
 ```typescript
@@ -1075,13 +1072,17 @@ const result = await algorand.send.payment({
 })
 ```
 
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.spec.ts)
+
 ## Methods
 
 ### assetCreate()
 
 > **assetCreate**(`params`): `Promise`\<\{ `assetId`: `bigint`; `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:257](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L257)
+Defined in: [src/types/algorand-client-transaction-sender.ts:251](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L251)
 
 Create a new Algorand Standard Asset.
 
@@ -1104,8 +1105,12 @@ The result of the asset create transaction and the transaction that was sent
 
 #### Examples
 
-```typescript
-await algorand.send.assetCreate({ sender: "CREATORADDRESS", total: 100n})
+```ts
+// Create a new asset
+const createResult = await algorand.send.assetCreate({ sender: alice, total: 100n })
+
+// Get the asset ID from the result
+const assetId = createResult.assetId
 ```
 
 ```typescript
@@ -1141,13 +1146,17 @@ await algorand.send.assetCreate({
 })
 ```
 
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.spec.ts)
+
 ***
 
 ### assetOptOut()
 
 > **assetOptOut**(`params`): `Promise`\<\{ `confirmation`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md); `confirmations`: [`PendingTransactionResponse`](../../../Subpaths/algod-client/type-aliases/PendingTransactionResponse.md)[]; `groupId`: `string` \| `undefined`; `returns?`: [`ABIReturn`](../../../Subpaths/abi/type-aliases/ABIReturn.md)[]; `transaction`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md); `transactions`: [`Transaction`](../../../Subpaths/transact/classes/Transaction.md)[]; `txIds`: `string`[]; \}\>
 
-Defined in: [src/types/algorand-client-transaction-sender.ts:513](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L513)
+Defined in: [src/types/algorand-client-transaction-sender.ts:507](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client-transaction-sender.ts#L507)
 
 Opt an account out of an Algorand Standard Asset.
 
@@ -1222,7 +1231,5 @@ A new instance of `TransactionComposer`.
 
 #### Example
 
-```ts
 const composer = AlgorandClient.mainNet().send.newGroup();
 const result = await composer.addTransaction(payment).send()
-```

--- a/docs/api/types/algorand-client/classes/AlgorandClient.md
+++ b/docs/api/types/algorand-client/classes/AlgorandClient.md
@@ -24,9 +24,7 @@ Get or create accounts that can sign transactions.
 
 ##### Example
 
-```ts
 const accountManager = AlgorandClient.mainNet().account;
-```
 
 ##### Returns
 
@@ -48,9 +46,7 @@ Methods for interacting with apps.
 
 ##### Example
 
-```ts
 const appManager = AlgorandClient.mainNet().app;
-```
 
 ##### Returns
 
@@ -72,9 +68,7 @@ Methods for deploying apps and managing app deployment metadata.
 
 ##### Example
 
-```ts
 const deployer = AlgorandClient.mainNet().appDeployer;
-```
 
 ##### Returns
 
@@ -96,9 +90,7 @@ Methods for interacting with assets.
 
 ##### Example
 
-```ts
 const assetManager = AlgorandClient.mainNet().asset;
-```
 
 ##### Returns
 
@@ -120,9 +112,7 @@ Get clients, including algosdk clients and app clients.
 
 ##### Example
 
-```ts
 const clientManager = AlgorandClient.mainNet().client;
-```
 
 ##### Returns
 
@@ -144,13 +134,11 @@ Methods for creating a transaction.
 
 ##### Example
 
-```ts
 const payment = await AlgorandClient.mainNet().createTransaction.payment({
  sender: "SENDERADDRESS",
  receiver: "RECEIVERADDRESS",
  amount: algo(1)
 })
-```
 
 ##### Returns
 
@@ -172,13 +160,11 @@ Methods for sending a transaction.
 
 ##### Example
 
-```ts
 const result = await AlgorandClient.mainNet().send.payment({
  sender: "SENDERADDRESS",
  receiver: "RECEIVERADDRESS",
  amount: algo(1)
 })
-```
 
 ##### Returns
 
@@ -204,9 +190,7 @@ The suggested transaction parameters.
 
 #### Example
 
-```ts
 const params = await AlgorandClient.mainNet().getSuggestedParams();
-```
 
 ***
 
@@ -233,9 +217,17 @@ A new instance of `TransactionComposer`.
 #### Example
 
 ```ts
-const composer = AlgorandClient.mainNet().newGroup();
-const result = await composer.addTransaction(payment).send()
+// Start a new transaction group with multiple payments and send
+const result = await algorand
+  .newGroup()
+  .addPayment({ sender: alice, receiver: bob, amount: AlgoAmount.MicroAlgo(1) })
+  .addPayment({ sender: alice, receiver: bob, amount: AlgoAmount.MicroAlgo(2) })
+  .send()
 ```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.spec.ts)
 
 ***
 
@@ -527,7 +519,7 @@ Defined in: [src/types/algorand-client.ts:223](https://github.com/algorandfounda
 
 > `static` **defaultLocalNet**(): `AlgorandClient`
 
-Defined in: [src/types/algorand-client.ts:281](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L281)
+Defined in: [src/types/algorand-client.ts:282](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L282)
 
 Creates an `AlgorandClient` pointing at default LocalNet ports and API token.
 
@@ -540,8 +532,22 @@ An instance of the `AlgorandClient`.
 #### Example
 
 ```ts
-const algorand = AlgorandClient.defaultLocalNet();
+// Create an AlgorandClient pointing at default LocalNet ports
+const algorand = AlgorandClient.defaultLocalNet()
+
+// Create a random account and fund it from the LocalNet dispenser
+const alice = algorand.account.random()
+
+await algorand.send.payment({
+  sender: await algorand.account.localNetDispenser(),
+  receiver: alice,
+  amount: (2).algo(),
+})
 ```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.spec.ts)
 
 ***
 
@@ -549,7 +555,7 @@ const algorand = AlgorandClient.defaultLocalNet();
 
 > `static` **fromClients**(`clients`): `AlgorandClient`
 
-Defined in: [src/types/algorand-client.ts:324](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L324)
+Defined in: [src/types/algorand-client.ts:325](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L325)
 
 Creates an `AlgorandClient` pointing to the given client(s).
 
@@ -569,9 +575,7 @@ An instance of the `AlgorandClient`.
 
 #### Example
 
-```ts
 const algorand = AlgorandClient.fromClients({ algod, indexer, kmd });
-```
 
 ***
 
@@ -579,7 +583,7 @@ const algorand = AlgorandClient.fromClients({ algod, indexer, kmd });
 
 > `static` **fromConfig**(`config`): `AlgorandClient`
 
-Defined in: [src/types/algorand-client.ts:358](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L358)
+Defined in: [src/types/algorand-client.ts:359](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L359)
 
 Creates  an `AlgorandClient` from the given config.
 
@@ -599,9 +603,7 @@ An instance of the `AlgorandClient`.
 
 #### Example
 
-```ts
 const client = AlgorandClient.fromConfig({ algodConfig, indexerConfig, kmdConfig });
-```
 
 ***
 
@@ -609,7 +611,7 @@ const client = AlgorandClient.fromConfig({ algodConfig, indexerConfig, kmdConfig
 
 > `static` **fromEnvironment**(): `AlgorandClient`
 
-Defined in: [src/types/algorand-client.ts:347](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L347)
+Defined in: [src/types/algorand-client.ts:348](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L348)
 
 Creates an `AlgorandClient` loading the configuration from environment variables.
 
@@ -634,9 +636,7 @@ An instance of the `AlgorandClient`.
 
 #### Example
 
-```ts
 const client = AlgorandClient.fromEnvironment();
-```
 
 ***
 
@@ -644,7 +644,7 @@ const client = AlgorandClient.fromEnvironment();
 
 > `static` **mainNet**(): `AlgorandClient`
 
-Defined in: [src/types/algorand-client.ts:309](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L309)
+Defined in: [src/types/algorand-client.ts:310](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L310)
 
 Creates an `AlgorandClient` pointing at MainNet using AlgoNode.
 
@@ -656,9 +656,7 @@ An instance of the `AlgorandClient`.
 
 #### Example
 
-```ts
 const algorand = AlgorandClient.mainNet();
-```
 
 ***
 
@@ -666,7 +664,7 @@ const algorand = AlgorandClient.mainNet();
 
 > `static` **testNet**(): `AlgorandClient`
 
-Defined in: [src/types/algorand-client.ts:295](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L295)
+Defined in: [src/types/algorand-client.ts:296](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.ts#L296)
 
 Creates an `AlgorandClient` pointing at TestNet using AlgoNode.
 
@@ -678,6 +676,4 @@ An instance of the `AlgorandClient`.
 
 #### Example
 
-```ts
 const algorand = AlgorandClient.testNet();
-```

--- a/docs/api/types/app-factory/classes/AppFactory.md
+++ b/docs/api/types/app-factory/classes/AppFactory.md
@@ -385,15 +385,9 @@ The method name or method signature to call if an ABI call is being emitted
 
 **Examples**
 
-```ts
-Method name
 `my_method`
-```
 
-```ts
-Method signature
 `my_method(unit64,string)bytes`
-```
 
 ###### note?
 
@@ -1213,15 +1207,9 @@ The method name or method signature to call if an ABI call is being emitted
 
 **Examples**
 
-```ts
-Method name
 `my_method`
-```
 
-```ts
-Method signature
 `my_method(unit64,string)bytes`
-```
 
 ###### note?
 
@@ -1415,15 +1403,9 @@ The method name or method signature to call if an ABI call is being emitted
 
 **Examples**
 
-```ts
-Method name
 `my_method`
-```
 
-```ts
-Method signature
 `my_method(unit64,string)bytes`
-```
 
 ###### note?
 
@@ -1579,15 +1561,9 @@ The method name or method signature to call if an ABI call is being emitted
 
 **Examples**
 
-```ts
-Method name
 `my_method`
-```
 
-```ts
-Method signature
 `my_method(unit64,string)bytes`
-```
 
 ###### note?
 

--- a/docs/api/types/asset-manager/classes/AssetManager.md
+++ b/docs/api/types/asset-manager/classes/AssetManager.md
@@ -50,7 +50,7 @@ const assetManager = new AssetManager(algod, () => new TransactionComposer({algo
 
 > **bulkOptIn**(`account`, `assetIds`, `options?`): `Promise`\<[`BulkAssetOptInOutResult`](../interfaces/BulkAssetOptInOutResult.md)[]\>
 
-Defined in: [src/types/asset-manager.ts:234](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset-manager.ts#L234)
+Defined in: [src/types/asset-manager.ts:229](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset-manager.ts#L229)
 
 Opt an account in to a list of Algorand Standard Assets.
 
@@ -84,12 +84,15 @@ An array of records matching asset ID to transaction ID of the opt in
 
 #### Example
 
-```typescript
-// Basic example
-assetManager.bulkOptIn("ACCOUNTADDRESS", [12345n, 67890n])
-// With configuration
-assetManager.bulkOptIn("ACCOUNTADDRESS", [12345n, 67890n], { maxFee: (1000).microAlgo(), suppressLog: true })
+```ts
+// Opt an account into multiple assets at once
+const assetIds = [dummyAssetId]
+await algorand.asset.bulkOptIn(secondAccount, assetIds)
 ```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.asset.spec.ts)
 
 ***
 
@@ -97,7 +100,7 @@ assetManager.bulkOptIn("ACCOUNTADDRESS", [12345n, 67890n], { maxFee: (1000).micr
 
 > **bulkOptOut**(`account`, `assetIds`, `options?`): `Promise`\<[`BulkAssetOptInOutResult`](../interfaces/BulkAssetOptInOutResult.md)[]\>
 
-Defined in: [src/types/asset-manager.ts:284](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset-manager.ts#L284)
+Defined in: [src/types/asset-manager.ts:275](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset-manager.ts#L275)
 
 Opt an account out of a list of Algorand Standard Assets.
 
@@ -131,12 +134,14 @@ An array of records matching asset ID to transaction ID of the opt in
 
 #### Example
 
-```typescript
-// Basic example
-assetManager.bulkOptOut("ACCOUNTADDRESS", [12345n, 67890n])
-// With configuration
-assetManager.bulkOptOut("ACCOUNTADDRESS", [12345n, 67890n], { ensureZeroBalance: true, maxFee: (1000).microAlgo(), suppressLog: true })
+```ts
+// Opt an account out of multiple assets at once
+await algorand.asset.bulkOptOut(secondAccount, assetIds)
 ```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.asset.spec.ts)
 
 ***
 
@@ -144,7 +149,7 @@ assetManager.bulkOptOut("ACCOUNTADDRESS", [12345n, 67890n], { ensureZeroBalance:
 
 > **getAccountInformation**(`sender`, `assetId`): `Promise`\<[`AccountAssetInformation`](../../account/type-aliases/AccountAssetInformation.md)\>
 
-Defined in: [src/types/asset-manager.ts:206](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset-manager.ts#L206)
+Defined in: [src/types/asset-manager.ts:205](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset-manager.ts#L205)
 
 Returns the given sender account's asset holding for a given asset.
 
@@ -184,7 +189,7 @@ const accountInfo = await assetManager.getAccountInformation(address, assetId);
 
 > **getById**(`assetId`): `Promise`\<[`AssetInformation`](../interfaces/AssetInformation.md)\>
 
-Defined in: [src/types/asset-manager.ts:168](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset-manager.ts#L168)
+Defined in: [src/types/asset-manager.ts:167](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/asset-manager.ts#L167)
 
 Returns the current asset information for the asset with the given ID.
 
@@ -204,6 +209,16 @@ The asset information
 
 #### Example
 
-```typescript
-const assetInfo = await assetManager.getById(12353n);
+```ts
+// Get asset information by ID
+const assetData = await algorand.asset.getById(result.assetId)
+
+// Access asset properties
+const creator = assetData.creator
+const total = assetData.total
+const decimals = assetData.decimals
 ```
+
+#### See
+
+[Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.asset.spec.ts)

--- a/docs/api/types/client-manager/classes/ClientManager.md
+++ b/docs/api/types/client-manager/classes/ClientManager.md
@@ -513,14 +513,12 @@ An instance of the TestNetDispenserApiClient class.
 
 #### Example
 
-```ts
 const client = clientManager.getTestNetDispenser(
     {
       authToken: 'your_auth_token',
       requestTimeout: 15,
     }
 )
-```
 
 ***
 
@@ -550,13 +548,11 @@ An instance of the TestNetDispenserApiClient class.
 
 #### Example
 
-```ts
 const client = clientManager.getTestNetDispenserFromEnvironment(
     {
       requestTimeout: 15,
     }
 )
-```
 
 ***
 

--- a/packages/abi/src/abi-method.spec.ts
+++ b/packages/abi/src/abi-method.spec.ts
@@ -60,3 +60,42 @@ describe('ABIMethod.getSignature round trip', () => {
     expect(regeneratedSignature).toBe(signature)
   })
 })
+
+describe('ABIMethod examples', () => {
+  test('ABIMethod.fromSignature parses method signatures', () => {
+    // #region example-ABIMethod-fromSignature
+    // Parse a method signature string into an ABIMethod object
+    const method = ABIMethod.fromSignature('add(uint64,uint64)uint64')
+
+    // Access method properties
+    const name = method.name // 'add'
+    const argCount = method.args.length // 2
+    // #endregion example-ABIMethod-fromSignature
+
+    expect(name).toBe('add')
+    expect(argCount).toBe(2)
+  })
+
+  test('ABIMethod.getSelector returns 4-byte selector', () => {
+    // #region example-ABIMethod-getSelector
+    // Get the 4-byte method selector for ABI method calls
+    const method = ABIMethod.fromSignature('add(uint64,uint64)uint64')
+    const selector = method.getSelector()
+
+    // Selector is the first 4 bytes of SHA-512/256 hash of the signature
+    // #endregion example-ABIMethod-getSelector
+
+    expect(selector).toHaveLength(4)
+    expect(Buffer.from(selector).toString('hex')).toBe('fe6bdf69')
+  })
+
+  test('ABIMethod.getSignature returns the signature', () => {
+    // #region example-ABIMethod-getSignature
+    // Get the full method signature string
+    const method = ABIMethod.fromSignature('transfer(address,uint64)bool')
+    const signature = method.getSignature()
+    // #endregion example-ABIMethod-getSignature
+
+    expect(signature).toBe('transfer(address,uint64)bool')
+  })
+})

--- a/packages/abi/src/abi-method.ts
+++ b/packages/abi/src/abi-method.ts
@@ -98,6 +98,9 @@ export class ABIMethod {
   /**
    * Returns the signature of this ABI method.
    * @returns The signature, e.g. `my_method(unit64,string)bytes`
+   * @example
+   * {@includeCode ./abi-method.spec.ts#example-ABIMethod-getSignature}
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.spec.ts)
    */
   getSignature(): string {
     const args = this.args
@@ -113,6 +116,9 @@ export class ABIMethod {
   /**
    * Returns the method selector of this ABI method.
    * @returns The 4-byte method selector
+   * @example
+   * {@includeCode ./abi-method.spec.ts#example-ABIMethod-getSelector}
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.spec.ts)
    */
   getSelector(): Uint8Array {
     const hash = sha512.sha512_256.array(this.getSignature())
@@ -124,6 +130,9 @@ export class ABIMethod {
    * @param signature The method signature
    * e.g. `my_method(unit64,string)bytes`
    * @returns The `ABIMethod`
+   * @example
+   * {@includeCode ./abi-method.spec.ts#example-ABIMethod-fromSignature}
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-method.spec.ts)
    */
   static fromSignature(signature: string): ABIMethod {
     const argsStart = signature.indexOf('(')

--- a/packages/abi/src/abi-type.spec.ts
+++ b/packages/abi/src/abi-type.spec.ts
@@ -602,4 +602,48 @@ describe('ABIType encode decode', () => {
     expect(() => new ABIArrayDynamicType(new ABIAddressType()).encode([false])).toThrow()
     expect(() => new ABITupleType([new ABIBoolType(), new ABIUfixedType(128, 20)]).encode([BigInt(3), true])).toThrow()
   })
+
+  describe('ABIType examples', () => {
+    test('ABIType.from parses type strings', () => {
+      // #region example-ABIType-from
+      // Parse ABI type strings into type objects
+      const uint64Type = ABIType.from('uint64')
+      const tupleType = ABIType.from('(uint64,string,bool)')
+      const arrayType = ABIType.from('uint32[]')
+
+      // Use the type name property
+      const typeName = uint64Type.name // 'uint64'
+      // #endregion example-ABIType-from
+
+      expect(typeName).toBe('uint64')
+      expect(tupleType.name).toBe('(uint64,string,bool)')
+      expect(arrayType.name).toBe('uint32[]')
+    })
+
+    test('ABIType encode and decode values', () => {
+      // #region example-ABIType-encode-decode
+      // Create an ABI type and encode a value
+      const uint64Type = ABIType.from('uint64')
+      const encoded = uint64Type.encode(42n)
+
+      // Decode bytes back to a value
+      const decoded = uint64Type.decode(encoded)
+      // #endregion example-ABIType-encode-decode
+
+      expect(decoded).toBe(42n)
+    })
+
+    test('ABITupleType encode and decode', () => {
+      // #region example-ABITupleType
+      // Create a tuple type and encode structured data
+      const tupleType = ABIType.from('(uint64,string,bool)')
+      const encoded = tupleType.encode([123n, 'hello', true])
+
+      // Decode back to tuple values
+      const decoded = tupleType.decode(encoded)
+      // #endregion example-ABITupleType
+
+      expect(decoded).toEqual([123n, 'hello', true])
+    })
+  })
 })

--- a/packages/abi/src/abi-type.ts
+++ b/packages/abi/src/abi-type.ts
@@ -96,6 +96,9 @@ export abstract class ABIType {
    * Creates an ABI type from an ARC-4 type string.
    * @param str The ARC-4 type string (e.g., "uint256", "bool", "(uint8,address)")
    * @returns The corresponding ABI type
+   * @example
+   * {@includeCode ./abi-type.spec.ts#example-ABIType-from}
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/abi/src/abi-type.spec.ts)
    */
   static from(str: string): ABIType {
     if (str.endsWith('[]')) {

--- a/packages/transact/src/multisig.spec.ts
+++ b/packages/transact/src/multisig.spec.ts
@@ -7,13 +7,18 @@ import { multisigSignatureCodec } from './transactions/signed-transaction-meta'
 describe('multisig', () => {
   describe('MultisigAccount.createMultisigSignature', () => {
     test('should create empty multisig signature with correct structure', () => {
+      // #region example-MultisigAccount-create
+      // Create a multisig account with 2-of-2 threshold
       const addrs = [
         'RIMARGKZU46OZ77OLPDHHPUJ7YBSHRTCYMQUC64KZCCMESQAFQMYU6SL2Q',
         'ALGOC4J2BCZ33TCKSSAMV5GAXQBMV3HDCHDBSPRBZRNSR7BM2FFDZRFGXA',
       ].map((s) => Address.fromString(s))
 
       const msigAccount = new MultisigAccount({ version: 1, threshold: 2, addrs }, [])
+
+      // Create an empty multisig signature structure
       const multisig = msigAccount.createMultisigSignature()
+      // #endregion example-MultisigAccount-create
 
       expect(multisig.version).toBe(1)
       expect(multisig.threshold).toBe(2)

--- a/packages/transact/src/multisig.ts
+++ b/packages/transact/src/multisig.ts
@@ -383,7 +383,12 @@ export interface MultisigMetadata {
   addrs: Array<Address>
 }
 
-/** Account wrapper that supports partial or full multisig signing. */
+/**
+ * Account wrapper that supports partial or full multisig signing.
+ * @example
+ * {@includeCode ./multisig.spec.ts#example-MultisigAccount-create}
+ * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/multisig.spec.ts)
+ */
 export class MultisigAccount implements AddressWithTransactionSigner, AddressWithDelegatedLsigSigner {
   _params: MultisigMetadata
   _subSigners: (AddressWithTransactionSigner & AddressWithDelegatedLsigSigner)[]

--- a/packages/transact/src/signer.spec.ts
+++ b/packages/transact/src/signer.spec.ts
@@ -4,15 +4,28 @@ import { generateAddressWithSigners } from './signer'
 
 describe('signer', () => {
   test('generateSigners', async () => {
+    // #region example-generateAddressWithSigners
+    // Generate signers from an ed25519 keypair
     const keypair = nacl.sign.keyPair()
+
+    // Create a raw signing callback
     const rawSigner = async (bytesToSign: Uint8Array): Promise<Uint8Array> => {
       return nacl.sign.detached(bytesToSign, keypair.secretKey)
     }
 
-    const addressWithSigners = generateAddressWithSigners({ ed25519Pubkey: keypair.publicKey, rawEd25519Signer: rawSigner })
+    // Generate all signer types from the keypair
+    const addressWithSigners = generateAddressWithSigners({
+      ed25519Pubkey: keypair.publicKey,
+      rawEd25519Signer: rawSigner,
+    })
 
-    expect(addressWithSigners.addr.publicKey).toEqual(keypair.publicKey)
-    expect(addressWithSigners.signer).toBeDefined()
+    // Access the address and various signers
+    const address = addressWithSigners.addr
+    const transactionSigner = addressWithSigners.signer
+    // #endregion example-generateAddressWithSigners
+
+    expect(address.publicKey).toEqual(keypair.publicKey)
+    expect(transactionSigner).toBeDefined()
     expect(addressWithSigners.lsigSigner).toBeDefined()
     expect(addressWithSigners.programDataSigner).toBeDefined()
     expect(addressWithSigners.mxBytesSigner).toBeDefined()

--- a/packages/transact/src/signer.ts
+++ b/packages/transact/src/signer.ts
@@ -42,6 +42,9 @@ const SIGN_BYTES_PREFIX = Uint8Array.from([77, 88]) // "MX"
  * @param args.sendingAddress - The address that will be used as the sender of transactions. If not provided, defaults to the address derived from the ed25519 public key. This is useful when signing for a rekeyed account where the sending address differs from the auth address.
  * @param args.rawEd25519Signer - A callback function that signs raw bytes using the ed25519 private key
  * @returns An object containing the sending address and various signer functions
+ * @example
+ * {@includeCode ./signer.spec.ts#example-generateAddressWithSigners}
+ * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/packages/transact/src/signer.spec.ts)
  */
 export function generateAddressWithSigners(args: {
   ed25519Pubkey: Uint8Array

--- a/src/amount.ts
+++ b/src/amount.ts
@@ -59,6 +59,7 @@ BigInt.prototype.algo = function () {
  * @param algos The amount of Algo
  * @example
  * {@includeCode ./types/amount.spec.ts#example-algos}
+ * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/amount.spec.ts)
  */
 export const algos = (algos: number | bigint) => {
   return AlgoAmount.Algo(algos)
@@ -68,6 +69,7 @@ export const algos = (algos: number | bigint) => {
  * @param algos The amount of Algo
  * @example
  * {@includeCode ./types/amount.spec.ts#example-algo}
+ * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/amount.spec.ts)
  */
 export const algo = (algos: number | bigint) => {
   return AlgoAmount.Algo(algos)
@@ -77,6 +79,7 @@ export const algo = (algos: number | bigint) => {
  * @param microAlgos The amount of µAlgo
  * @example
  * {@includeCode ./types/amount.spec.ts#example-microAlgos}
+ * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/amount.spec.ts)
  */
 export const microAlgos = (microAlgos: number | bigint) => {
   return AlgoAmount.MicroAlgo(microAlgos)
@@ -86,6 +89,7 @@ export const microAlgos = (microAlgos: number | bigint) => {
  * @param microAlgos The amount of µAlgo
  * @example
  * {@includeCode ./types/amount.spec.ts#example-microAlgo}
+ * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/amount.spec.ts)
  */
 export const microAlgo = (microAlgos: number | bigint) => {
   return AlgoAmount.MicroAlgo(microAlgos)
@@ -95,6 +99,7 @@ export const microAlgo = (microAlgos: number | bigint) => {
  * @param numberOfTransactions The of standard transaction fees to return the amount of Algo
  * @example
  * {@includeCode ./types/amount.spec.ts#example-transactionFees}
+ * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/amount.spec.ts)
  */
 export const transactionFees = (numberOfTransactions: number) => {
   return AlgoAmount.MicroAlgo(BigInt(numberOfTransactions) * ALGORAND_MIN_TX_FEE.microAlgo)

--- a/src/amount.ts
+++ b/src/amount.ts
@@ -57,6 +57,8 @@ BigInt.prototype.algo = function () {
 
 /** Returns an amount of Algo using AlgoAmount
  * @param algos The amount of Algo
+ * @example
+ * {@includeCode ./types/amount.spec.ts#example-algos}
  */
 export const algos = (algos: number | bigint) => {
   return AlgoAmount.Algo(algos)
@@ -64,6 +66,8 @@ export const algos = (algos: number | bigint) => {
 
 /** Returns an amount of Algo using AlgoAmount
  * @param algos The amount of Algo
+ * @example
+ * {@includeCode ./types/amount.spec.ts#example-algo}
  */
 export const algo = (algos: number | bigint) => {
   return AlgoAmount.Algo(algos)
@@ -71,6 +75,8 @@ export const algo = (algos: number | bigint) => {
 
 /** Returns an amount of µAlgo using AlgoAmount
  * @param microAlgos The amount of µAlgo
+ * @example
+ * {@includeCode ./types/amount.spec.ts#example-microAlgos}
  */
 export const microAlgos = (microAlgos: number | bigint) => {
   return AlgoAmount.MicroAlgo(microAlgos)
@@ -78,6 +84,8 @@ export const microAlgos = (microAlgos: number | bigint) => {
 
 /** Returns an amount of µAlgo using AlgoAmount
  * @param microAlgos The amount of µAlgo
+ * @example
+ * {@includeCode ./types/amount.spec.ts#example-microAlgo}
  */
 export const microAlgo = (microAlgos: number | bigint) => {
   return AlgoAmount.MicroAlgo(microAlgos)
@@ -85,6 +93,8 @@ export const microAlgo = (microAlgos: number | bigint) => {
 
 /** Returns an amount of µAlgo to cover standard fees for the given number of transactions using AlgoAmount
  * @param numberOfTransactions The of standard transaction fees to return the amount of Algo
+ * @example
+ * {@includeCode ./types/amount.spec.ts#example-transactionFees}
  */
 export const transactionFees = (numberOfTransactions: number) => {
   return AlgoAmount.MicroAlgo(BigInt(numberOfTransactions) * ALGORAND_MIN_TX_FEE.microAlgo)

--- a/src/types/algorand-client-transaction-sender.ts
+++ b/src/types/algorand-client-transaction-sender.ts
@@ -167,13 +167,7 @@ export class AlgorandClientTransactionSender {
    * Send a payment transaction to transfer Algo between accounts.
    * @param params The parameters for the payment transaction
    * @example Basic example
-   * ```typescript
-   * const result = await algorand.send.payment({
-   *  sender: 'SENDERADDRESS',
-   *  receiver: 'RECEIVERADDRESS',
-   *  amount: (4).algo(),
-   * })
-   * ```
+   * {@includeCode ./algorand-client.spec.ts#example-send-payment}
    * @example Advanced example
    * ```typescript
    * const result = await algorand.send.payment({
@@ -201,6 +195,7 @@ export class AlgorandClientTransactionSender {
    *   suppressLog: true,
    * })
    * ```
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.spec.ts)
    * @returns The result of the payment transaction and the transaction that was sent
    */
   payment = this._send((c) => c.addPayment, {
@@ -216,9 +211,7 @@ export class AlgorandClientTransactionSender {
    * @param params The parameters for the asset creation transaction
    *
    * @example Basic example
-   * ```typescript
-   * await algorand.send.assetCreate({ sender: "CREATORADDRESS", total: 100n})
-   * ```
+   * {@includeCode ./algorand-client.spec.ts#example-send-asset-create}
    * @example Advanced example
    * ```typescript
    * await algorand.send.assetCreate({
@@ -252,6 +245,7 @@ export class AlgorandClientTransactionSender {
    *   suppressLog: true,
    * })
    * ```
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.spec.ts)
    * @returns The result of the asset create transaction and the transaction that was sent
    */
   assetCreate = async (params: AssetCreateParams & SendParams) => {

--- a/src/types/algorand-client.asset.spec.ts
+++ b/src/types/algorand-client.asset.spec.ts
@@ -26,10 +26,20 @@ describe('Asset capability', () => {
     })
 
     expect(result.confirmation.assetId).toBeGreaterThan(0n)
+
+    // #region example-getById
+    // Get asset information by ID
     const assetData = await algorand.asset.getById(result.assetId)
-    expect(assetData.creator).toBe(testAccount.toString())
-    expect(assetData.total).toBe(1000n)
-    expect(assetData.decimals).toBe(0)
+
+    // Access asset properties
+    const creator = assetData.creator
+    const total = assetData.total
+    const decimals = assetData.decimals
+    // #endregion example-getById
+
+    expect(creator).toBe(testAccount.toString())
+    expect(total).toBe(1000n)
+    expect(decimals).toBe(0)
     expect(assetData.defaultFrozen).toBe(true)
     expect(assetData.unitName).toBe('TEST')
     expect(assetData.assetName).toBe('Test Asset')
@@ -44,13 +54,16 @@ describe('Asset capability', () => {
   test('OptIn an asset to an account succeed', async () => {
     const { algorand, testAccount, generateAccount } = localnet.context
     const dummyAssetId = await generateTestAsset(algorand, testAccount, 1)
-    const dummyAssetIds = [dummyAssetId]
     const secondAccount = await generateAccount({ initialFunds: (1).algo() })
 
     const secondAccountInfo = await algorand.account.getInformation(secondAccount)
     expect(secondAccountInfo.totalAssetsOptedIn).toBe(0)
 
-    await algorand.asset.bulkOptIn(secondAccount, dummyAssetIds, { validityWindow: 100 })
+    // #region example-bulkOptIn
+    // Opt an account into multiple assets at once
+    const assetIds = [dummyAssetId]
+    await algorand.asset.bulkOptIn(secondAccount, assetIds)
+    // #endregion example-bulkOptIn
 
     const testAccountInfoAfterOptIn = await algorand.account.getInformation(secondAccount)
     expect(testAccountInfoAfterOptIn.totalAssetsOptedIn).toBe(1)
@@ -73,15 +86,18 @@ describe('Asset capability', () => {
     const { algorand, testAccount, generateAccount } = localnet.context
     const dummyAssetId = await generateTestAsset(algorand, testAccount, 0)
     const dummyAssetId2 = await generateTestAsset(algorand, testAccount, 0)
-    const dummyAssetIds = [dummyAssetId, dummyAssetId2]
+    const assetIds = [dummyAssetId, dummyAssetId2]
     const secondAccount = await generateAccount({ initialFunds: (1).algo() })
 
-    await algorand.asset.bulkOptIn(secondAccount, dummyAssetIds, { validityWindow: 100 })
+    await algorand.asset.bulkOptIn(secondAccount, assetIds, { validityWindow: 100 })
 
     const secondAccountInfo = await algorand.account.getInformation(secondAccount)
     expect(secondAccountInfo.totalAssetsOptedIn).toBe(2)
 
-    await algorand.asset.bulkOptOut(secondAccount, dummyAssetIds, { validityWindow: 100 })
+    // #region example-bulkOptOut
+    // Opt an account out of multiple assets at once
+    await algorand.asset.bulkOptOut(secondAccount, assetIds)
+    // #endregion example-bulkOptOut
 
     const secondAccountInfoAfterOptOut = await algorand.account.getInformation(secondAccount)
     expect(secondAccountInfoAfterOptOut.totalAssetsOptedIn).toBe(0)

--- a/src/types/algorand-client.spec.ts
+++ b/src/types/algorand-client.spec.ts
@@ -45,7 +45,12 @@ describe('AlgorandClient', () => {
   test('sendPayment', async () => {
     const alicePreBalance = (await algorand.account.getInformation(alice)).balance
     const bobPreBalance = (await algorand.account.getInformation(bob)).balance
+
+    // #region example-send-payment
+    // Send a payment transaction
     await algorand.send.payment({ sender: alice, receiver: bob, amount: AlgoAmount.MicroAlgo(1) })
+    // #endregion example-send-payment
+
     const alicePostBalance = (await algorand.account.getInformation(alice)).balance
     const bobPostBalance = (await algorand.account.getInformation(bob)).balance
 
@@ -54,9 +59,28 @@ describe('AlgorandClient', () => {
   })
 
   test('sendAssetCreate', async () => {
+    // #region example-send-asset-create
+    // Create a new asset
     const createResult = await algorand.send.assetCreate({ sender: alice, total: 100n })
 
-    expect(createResult.assetId).toBeGreaterThan(0)
+    // Get the asset ID from the result
+    const assetId = createResult.assetId
+    // #endregion example-send-asset-create
+
+    expect(assetId).toBeGreaterThan(0)
+  })
+
+  test('newGroup example', async () => {
+    // #region example-newGroup
+    // Start a new transaction group with multiple payments and send
+    const result = await algorand
+      .newGroup()
+      .addPayment({ sender: alice, receiver: bob, amount: AlgoAmount.MicroAlgo(1) })
+      .addPayment({ sender: alice, receiver: bob, amount: AlgoAmount.MicroAlgo(2) })
+      .send()
+    // #endregion example-newGroup
+
+    expect(result.transactions.length).toBe(2)
   })
 
   test('addTransactionComposer from generated client', async () => {
@@ -280,8 +304,11 @@ describe('AlgorandClient', () => {
   })
 
   test('issue more than non-LocalNet default validity window transactions against LocalNet works', async () => {
+    // #region example-defaultLocalNet
+    // Create an AlgorandClient pointing at default LocalNet ports
     const algorand = AlgorandClient.defaultLocalNet()
 
+    // Create a random account and fund it from the LocalNet dispenser
     const alice = algorand.account.random()
 
     await algorand.send.payment({
@@ -289,6 +316,7 @@ describe('AlgorandClient', () => {
       receiver: alice,
       amount: (2).algo(),
     })
+    // #endregion example-defaultLocalNet
 
     // Default validity window is 10
     for (let i = 0; i < 10; i++) {

--- a/src/types/algorand-client.ts
+++ b/src/types/algorand-client.ts
@@ -228,6 +228,7 @@ export class AlgorandClient {
    * @returns A new instance of `TransactionComposer`.
    * @example
    * {@includeCode ./algorand-client.spec.ts#example-newGroup}
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.spec.ts)
    */
   public newGroup(composerConfig?: TransactionComposerConfig) {
     return new TransactionComposer({
@@ -276,6 +277,7 @@ export class AlgorandClient {
    * @returns An instance of the `AlgorandClient`.
    * @example
    * {@includeCode ./algorand-client.spec.ts#example-defaultLocalNet}
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.spec.ts)
    */
   public static defaultLocalNet() {
     return new AlgorandClient({

--- a/src/types/algorand-client.ts
+++ b/src/types/algorand-client.ts
@@ -227,8 +227,7 @@ export class AlgorandClient {
   /** Start a new `TransactionComposer` transaction group
    * @returns A new instance of `TransactionComposer`.
    * @example
-   * const composer = AlgorandClient.mainNet().newGroup();
-   * const result = await composer.addTransaction(payment).send()
+   * {@includeCode ./algorand-client.spec.ts#example-newGroup}
    */
   public newGroup(composerConfig?: TransactionComposerConfig) {
     return new TransactionComposer({
@@ -276,7 +275,7 @@ export class AlgorandClient {
    * Creates an `AlgorandClient` pointing at default LocalNet ports and API token.
    * @returns An instance of the `AlgorandClient`.
    * @example
-   * const algorand = AlgorandClient.defaultLocalNet();
+   * {@includeCode ./algorand-client.spec.ts#example-defaultLocalNet}
    */
   public static defaultLocalNet() {
     return new AlgorandClient({

--- a/src/types/amount.spec.ts
+++ b/src/types/amount.spec.ts
@@ -10,10 +10,34 @@ describe('amount', () => {
     expect(`${algos(100)}`).toBe(`100,000,000 µALGO`)
   })
   test('microalgos to microalgos', () => {
-    expect(microAlgos(100).microAlgo).toBe(100n)
+    // #region example-microAlgos
+    // Create an amount of 100 microAlgo
+    const amount = microAlgos(100)
+
+    // Access the value in microAlgo
+    const microAlgoValue = amount.microAlgo // 100n
+
+    // Access the value in Algo
+    const algoValue = amount.algo // 0.0001
+    // #endregion example-microAlgos
+
+    expect(microAlgoValue).toBe(100n)
+    expect(algoValue).toBe(0.0001)
   })
   test('algos to microalgos', () => {
-    expect(algos(100).microAlgo).toBe(100_000_000n)
+    // #region example-algos
+    // Create an amount of 100 Algo
+    const amount = algos(100)
+
+    // Access the value in microAlgo (100 * 1_000_000)
+    const microAlgoValue = amount.microAlgo // 100_000_000n
+
+    // Access the value in Algo
+    const algoValue = amount.algo // 100
+    // #endregion example-algos
+
+    expect(microAlgoValue).toBe(100_000_000n)
+    expect(algoValue).toBe(100)
   })
   test('algos to algos', () => {
     expect(algos(100).algo).toBe(100)
@@ -24,19 +48,45 @@ describe('amount', () => {
   test('large microalgos to algos', () => {
     expect(microAlgos(100_000_000).algo).toBe(100)
   })
-  test('single transaction fee', () => {
-    expect(transactionFees(1).microAlgo).toBe(1_000n)
-  })
-  test('multiple transaction fees', () => {
-    expect(transactionFees(10).microAlgo).toBe(10_000n)
+  test('single and multiple transaction fee', () => {
+    // #region example-transactionFees
+    // Get the fee amount for a single transaction (1000 microAlgo)
+    const singleFee = transactionFees(1)
+
+    // Get the fee amount for multiple transactions
+    const multipleFees = transactionFees(10)
+
+    // Access the values
+    const singleFeeValue = singleFee.microAlgo // 1_000n
+    const multipleFeeValue = multipleFees.microAlgo // 10_000n
+    // #endregion example-transactionFees
+
+    expect(singleFeeValue).toBe(1_000n)
+    expect(multipleFeeValue).toBe(10_000n)
   })
   test('algos via Number.prototype', () => {
-    expect((100).algo()).toBeInstanceOf(AlgoAmount)
-    expect((100).algo().algo).toBe(100)
+    // #region example-algo
+    // Create an AlgoAmount using the Number.prototype extension
+    const amount = (100).algo()
+
+    // Access the value in Algo
+    const algoValue = amount.algo // 100
+    // #endregion example-algo
+
+    expect(amount).toBeInstanceOf(AlgoAmount)
+    expect(algoValue).toBe(100)
   })
   test('microAlgos via Number.prototype', () => {
-    expect((100).microAlgo()).toBeInstanceOf(AlgoAmount)
-    expect((100).microAlgo().microAlgo).toBe(100n)
+    // #region example-microAlgo
+    // Create an AlgoAmount using the Number.prototype extension
+    const amount = (100).microAlgo()
+
+    // Access the value in microAlgo
+    const microAlgoValue = amount.microAlgo // 100n
+    // #endregion example-microAlgo
+
+    expect(amount).toBeInstanceOf(AlgoAmount)
+    expect(microAlgoValue).toBe(100n)
   })
 })
 

--- a/src/types/asset-manager.ts
+++ b/src/types/asset-manager.ts
@@ -158,9 +158,8 @@ export class AssetManager {
    * Returns the current asset information for the asset with the given ID.
    *
    * @example
-   * ```typescript
-   * const assetInfo = await assetManager.getById(12353n);
-   * ```
+   * {@includeCode ./algorand-client.asset.spec.ts#example-getById}
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.asset.spec.ts)
    *
    * @param assetId The ID of the asset
    * @returns The asset information
@@ -222,13 +221,9 @@ export class AssetManager {
    * @param account The account to opt-in
    * @param assetIds The list of asset IDs to opt-in to
    * @param options Any parameters to control the transaction or execution of the transaction
-   * @example Example using AlgorandClient
-   * ```typescript
-   * // Basic example
-   * assetManager.bulkOptIn("ACCOUNTADDRESS", [12345n, 67890n])
-   * // With configuration
-   * assetManager.bulkOptIn("ACCOUNTADDRESS", [12345n, 67890n], { maxFee: (1000).microAlgo(), suppressLog: true })
-   * ```
+   * @example
+   * {@includeCode ./algorand-client.asset.spec.ts#example-bulkOptIn}
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.asset.spec.ts)
    * @returns An array of records matching asset ID to transaction ID of the opt in
    */
   async bulkOptIn(
@@ -272,13 +267,9 @@ export class AssetManager {
    * @param account The account to opt-in
    * @param assetIds The list of asset IDs to opt-out of
    * @param options Any parameters to control the transaction or execution of the transaction
-   * @example Example using AlgorandClient
-   * ```typescript
-   * // Basic example
-   * assetManager.bulkOptOut("ACCOUNTADDRESS", [12345n, 67890n])
-   * // With configuration
-   * assetManager.bulkOptOut("ACCOUNTADDRESS", [12345n, 67890n], { ensureZeroBalance: true, maxFee: (1000).microAlgo(), suppressLog: true })
-   * ```
+   * @example
+   * {@includeCode ./algorand-client.asset.spec.ts#example-bulkOptOut}
+   * @see [Full working example](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.asset.spec.ts)
    * @returns An array of records matching asset ID to transaction ID of the opt in
    */
   async bulkOptOut(

--- a/typedoc.html.json
+++ b/typedoc.html.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://typedoc.org/schema.json",
+  "jsDocCompatibility": {
+    "exampleTag": false
+  },
   "entryPoints": [
     "src/index.ts",
     "src/abi/index.ts",

--- a/typedoc.markdown.json
+++ b/typedoc.markdown.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://typedoc.org/schema.json",
+  "jsDocCompatibility": {
+    "exampleTag": false
+  },
   "entryPoints": [
     "src/index.ts",
     "src/types/*.ts",


### PR DESCRIPTION
Added examples using `@includeDoc` tag intead of `@example` . Here are the high-level changes:

- Migrate inline @example code blocks to use TypeDoc's {@includeCode} directive, pulling examples directly from test files
- Add #region example-* markers to test files to define extractable code snippets
- Add jsDocCompatibility.exampleTag: false to TypeDoc configs to enable the new syntax
- Add @see links pointing to full working examples on GitHub