### PR TITLE
chore: add @noble/curves dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "dependencies": {
         "@algorandfoundation/xhd-wallet-api": "2.0.0-canary.1",
+        "@noble/curves": "^2.0.1",
         "@noble/ed25519": "^3.0.0",
         "@noble/hashes": "^2.0.1",
         "algorand-msgpack": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   },
   "dependencies": {
     "@algorandfoundation/xhd-wallet-api": "2.0.0-canary.1",
+    "@noble/curves": "^2.0.1",
     "@noble/ed25519": "^3.0.0",
     "@noble/hashes": "^2.0.1",
     "algorand-msgpack": "^1.1.0",


### PR DESCRIPTION
We now use the lower-level curves library for signing from the HD esk but didn't add it to the package.json. This resulted in "module not found" for external projects using the crypto package