### PR TITLE
chore: bump node to 24

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: 'Node.js version to use'
     required: false
-    default: '20.x'
+    default: '24.x'
   commit-lint-from:
     description: 'Git SHA to lint commits from'
     required: false
@@ -18,7 +18,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Run CI
         uses: ./.github/actions/ci
         with:
-          node-version: 20.x
+          node-version: 24.x
           commit-lint-from: ${{ github.event.pull_request.base.sha }}
           commit-lint-to: ${{ github.event.pull_request.head.sha }}
 
@@ -27,14 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - uses: pnpm/action-setup@v4
         with:
@@ -53,12 +53,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         id: app_token
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch entire repository history so we can determine version number from it
           fetch-depth: 0

--- a/.github/workflows/publish-devportal-docs.yml
+++ b/.github/workflows/publish-devportal-docs.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.x
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/publish-devportal-docs.yml
+++ b/.github/workflows/publish-devportal-docs.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run CI
         uses: ./.github/actions/ci
         with:
-          node-version: 22.x
+          node-version: 24.x
           commit-lint-from: ${{ github.event.before }}
           commit-lint-to: ${{ github.sha }}
 
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - uses: pnpm/action-setup@v4
         with:
@@ -65,7 +65,7 @@ jobs:
       - ci
       - check_docs
     with:
-      node-version: 22.x
+      node-version: 24.x
       build-path: dist
       artifact-name: package
 
@@ -93,10 +93,10 @@ jobs:
         run: git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com" && git config --global user.name "engineering-ci[bot]"
 
       # semantic-release v25+ needs node 22.14+
-      - name: Use Node.js 22.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download built package
@@ -139,7 +139,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
 
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
 
@@ -77,13 +77,13 @@ jobs:
       id-token: write
     steps:
       - name: Generate bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         id: app_token
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch entire repository history so we can determine version number from it
           fetch-depth: 0
@@ -94,13 +94,13 @@ jobs:
 
       # semantic-release v25+ needs node 22.14+
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download built package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: package
           path: artifacts
@@ -134,10 +134,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           cache: 'npm'

--- a/docs/scripts/generate-examples-mdx.ts
+++ b/docs/scripts/generate-examples-mdx.ts
@@ -9,7 +9,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { CATEGORIES, parseJSDoc, extractOrder, createSlug } from '../src/loaders/examples-loader.ts'
+import { CATEGORIES, createSlug, extractOrder, parseJSDoc } from '../src/loaders/examples-loader.ts'
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..')
 const EXAMPLES_DIR = path.join(REPO_ROOT, 'examples')
@@ -234,7 +234,7 @@ npm run example algorand_client/01-client-instantiation.ts
 
 ## Prerequisites
 
-- Node.js >= 20.0
+- Node.js >= 24
 - [AlgoKit CLI](https://github.com/algorandfoundation/algokit-cli) installed
 - LocalNet running for network examples (\`algokit localnet start\`)
 

--- a/docs/src/content/docs/tutorials/README.md
+++ b/docs/src/content/docs/tutorials/README.md
@@ -6,7 +6,7 @@ Get up and running with AlgoKit Utils in 5 minutes.
 
 ## Prerequisites
 
-- Node.js >= 20.0
+- Node.js >= 24.0
 - [AlgoKit CLI](https://github.com/algorandfoundation/algokit-cli) installed
 - LocalNet running (`algokit localnet start`)
 

--- a/docs/src/content/docs/tutorials/quick-start.md
+++ b/docs/src/content/docs/tutorials/quick-start.md
@@ -1,13 +1,13 @@
 ---
-title: "Quick Start"
-description: "Get up and running with AlgoKit Utils in 5 minutes."
+title: 'Quick Start'
+description: 'Get up and running with AlgoKit Utils in 5 minutes.'
 ---
 
 Get up and running with AlgoKit Utils in 5 minutes.
 
 ## Prerequisites
 
-- Node.js >= 20.0
+- Node.js >= 24
 - [AlgoKit CLI](https://github.com/algorandfoundation/algokit-cli) installed
 - LocalNet running (`algokit localnet start`)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ This folder contains 120 self-contained examples organized into 10 categories. E
 
 ## Prerequisites
 
-- Node.js >= 20.0
+- Node.js >= 24.0
 - [AlgoKit LocalNet](https://github.com/algorandfoundation/algokit-cli) running (for network examples)
 
 Some examples (marked "No LocalNet required") work with pure utility functions and don't need a running network.

--- a/examples/package.json
+++ b/examples/package.json
@@ -18,6 +18,6 @@
     "typescript": "^5.4.5"
   },
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@eslint/js": "^9.15.0",
         "@makerx/prettier-config": "^2.0.0",
         "@makerx/ts-toolkit": "4.0.0-beta.24",
-        "@tsconfig/node20": "^20.1.4",
+        "@tsconfig/node24": "^24.0.4",
         "@types/json-bigint": "^1.0.4",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.8.1",
@@ -2547,10 +2547,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+    "node_modules/@tsconfig/node24": {
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
+      "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/algorandfoundation/algokit-utils-ts.git"
   },
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "type": "commonjs",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@eslint/js": "^9.15.0",
     "@makerx/prettier-config": "^2.0.0",
     "@makerx/ts-toolkit": "4.0.0-beta.24",
-    "@tsconfig/node20": "^20.1.4",
+    "@tsconfig/node24": "^24.0.4",
     "@types/json-bigint": "^1.0.4",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.8.1",

--- a/packages/abi/package.json
+++ b/packages/abi/package.json
@@ -6,7 +6,7 @@
   "author": "Algorand Foundation",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/algo25/package.json
+++ b/packages/algo25/package.json
@@ -6,7 +6,7 @@
   "author": "Algorand Foundation",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/algod_client/package.json
+++ b/packages/algod_client/package.json
@@ -6,7 +6,7 @@
   "author": "Algorand Foundation",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "author": "Algorand Foundation",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -6,7 +6,7 @@
   "author": "Algorand Foundation",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/indexer_client/package.json
+++ b/packages/indexer_client/package.json
@@ -6,7 +6,7 @@
   "author": "Algorand Foundation",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/kmd_client/package.json
+++ b/packages/kmd_client/package.json
@@ -6,7 +6,7 @@
   "author": "Algorand Foundation",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -6,7 +6,7 @@
   "author": "Algorand Foundation",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/transact/package.json
+++ b/packages/transact/package.json
@@ -6,7 +6,7 @@
   "author": "Algorand Foundation",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node24/tsconfig.json",
   "compilerOptions": {
     "module": "ESNext",
     "target": "ES2022",


### PR DESCRIPTION
We need npm 11.5.1 for OIDC. Our package.json had node 20 which is about to EOL and 22 is about to go into maintenance, so seems to make sense to jump to 24 now