### PR TITLE
docs: fix broken api reference link

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -46,6 +46,7 @@ export default defineConfig({
           typeDoc: {
             excludeReferences: true,
             gitRevision: 'main',
+            entryFileName: 'index',
           },
         }),
       ],


### PR DESCRIPTION
## Summary
- The "API Reference" hero button on the docs homepage linked to `/algokit-utils-ts/api/`, which returned a 404
- Root cause: `starlight-typedoc` generates `README.md` by default, but Starlight routes that to `/api/readme/`, not `/api/`
- Fix: set `entryFileName: 'index'` in the typeDoc config so module root pages are generated as `index.md`

Address #566 