### PR TITLE
ci: publish docs to gh pages on main brench merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
     needs:
       - ci
       - check_docs
-    if: github.ref == 'refs/heads/decoupling'
+    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary

The `publish_docs` job in the release workflow was still pointing at the `decoupling` branch instead of `main`, so documentation was not being deployed to GitHub Pages on merge to main.
