### PR TITLE
fix: generated hd seed size

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -29,6 +29,8 @@ runs:
 
     - name: Setup Polytest
       uses: algorandfoundation/algokit-polytest/.github/actions/setup-polytest@main
+      with:
+        version: 0.7.0
 
     - name: Validate polytest algod_client tests
       shell: bash

--- a/packages/crypto/src/hd.ts
+++ b/packages/crypto/src/hd.ts
@@ -24,7 +24,7 @@ export type HdAccountGenerator = (
 const xhd = new XHDWalletAPI()
 
 export const peikertXHdWalletGenerator: HdWalletGenerator = async (seed?: Uint8Array) => {
-  const seedArray = seed ?? new Uint8Array(32)
+  const seedArray = seed ?? new Uint8Array(64)
   if (seed === undefined) {
     crypto.getRandomValues(seedArray)
   }


### PR DESCRIPTION
Previously when a seed wasn't provided to the HD generator a random 32-byte value was generated. This fix correctly changes that to 64 bytes as expected by `fromSeed`

https://github.com/algorandfoundation/xHD-Wallet-API-ts/blob/15e6f1990f93dcccb21a1ff7c7f1cea8792b8733/src/bip32-ed25519.ts#L20-L20