### PR TITLE
docs: fix 404 urls and rename api modules from subpaths to algokit-utils

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from '@astrojs/starlight'
 import { defineConfig } from 'astro/config'
 import remarkGithubAlerts from 'remark-github-alerts'
 import starlightTypeDoc from 'starlight-typedoc'
+import remarkFixIndexUrls from './plugins/remark-fix-index-urls'
 import sidebarConfig from './sidebar.config.json'
 
 // https://astro.build/config
@@ -10,7 +11,7 @@ export default defineConfig({
   site: 'https://algorandfoundation.github.io',
   base: '/algokit-utils-ts/',
   markdown: {
-    remarkPlugins: [remarkGithubAlerts],
+    remarkPlugins: [remarkGithubAlerts, remarkFixIndexUrls],
   },
   integrations: [
     starlight({
@@ -31,11 +32,12 @@ export default defineConfig({
             '../src/testing/index.ts',
             '../src/abi/index.ts',
             '../src/transact/index.ts',
-            '../src/transaction/index.ts',
             '../src/algod-client/index.ts',
             '../src/indexer-client/index.ts',
             '../src/kmd-client/index.ts',
             '../src/algo25/index.ts',
+            '../src/common/index.ts',
+            '../src/crypto/index.ts',
           ],
           tsconfig: '../tsconfig.build.json',
           output: 'api',

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,6 +22,8 @@
     "typedoc-plugin-markdown": "^4.9.0"
   },
   "devDependencies": {
-    "tsx": "^4.21.0"
+    "@types/mdast": "^4.0.4",
+    "tsx": "^4.21.0",
+    "unist-util-visit": "^5.1.0"
   }
 }

--- a/docs/plugins/remark-fix-index-urls.ts
+++ b/docs/plugins/remark-fix-index-urls.ts
@@ -1,0 +1,17 @@
+import type { Link, Root } from 'mdast'
+import { visit } from 'unist-util-visit'
+
+/**
+ * Remark plugin that removes trailing `/index/` from internal links.
+ *
+ * Starlight serves `index.md` files at the parent directory URL, but
+ * starlight-typedoc generates links with an explicit `/index/` segment.
+ * e.g. `/algokit-utils-ts/api/algokit-utils/abi/index/` → `/algokit-utils-ts/api/algokit-utils/abi/`
+ */
+export default function remarkFixIndexUrls() {
+  return (tree: Root) => {
+    visit(tree, 'link', (node: Link) => {
+      node.url = node.url.replace(/\/index\/$/, '/')
+    })
+  }
+}

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -30,9 +30,15 @@ importers:
         specifier: ^4.9.0
         version: 4.10.0(typedoc@0.28.17(typescript@5.9.3))
     devDependencies:
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
 
 packages:
 

--- a/docs/sidebar.config.json
+++ b/docs/sidebar.config.json
@@ -66,14 +66,15 @@
     "collapsed": true,
     "items": [
       { "label": "algokit-utils", "autogenerate": { "directory": "api/algokit-utils" } },
-      { "label": "Subpaths/abi", "autogenerate": { "directory": "api/Subpaths/abi" } },
-      { "label": "Subpaths/algo25", "autogenerate": { "directory": "api/Subpaths/algo25" } },
-      { "label": "Subpaths/algod-client", "autogenerate": { "directory": "api/Subpaths/algod-client" } },
-      { "label": "Subpaths/indexer-client", "autogenerate": { "directory": "api/Subpaths/indexer-client" } },
-      { "label": "Subpaths/kmd-client", "autogenerate": { "directory": "api/Subpaths/kmd-client" } },
-      { "label": "Subpaths/testing", "autogenerate": { "directory": "api/Subpaths/testing" } },
-      { "label": "Subpaths/transact", "autogenerate": { "directory": "api/Subpaths/transact" } },
-      { "label": "Subpaths/transaction", "autogenerate": { "directory": "api/Subpaths/transaction" } }
+      { "label": "algokit-utils/abi", "autogenerate": { "directory": "api/algokit-utils/abi" } },
+      { "label": "algokit-utils/algo25", "autogenerate": { "directory": "api/algokit-utils/algo25" } },
+      { "label": "algokit-utils/algod-client", "autogenerate": { "directory": "api/algokit-utils/algod-client" } },
+      { "label": "algokit-utils/indexer-client", "autogenerate": { "directory": "api/algokit-utils/indexer-client" } },
+      { "label": "algokit-utils/kmd-client", "autogenerate": { "directory": "api/algokit-utils/kmd-client" } },
+      { "label": "algokit-utils/testing", "autogenerate": { "directory": "api/algokit-utils/testing" } },
+      { "label": "algokit-utils/transact", "autogenerate": { "directory": "api/algokit-utils/transact" } },
+      { "label": "algokit-utils/common", "autogenerate": { "directory": "api/algokit-utils/common" } },
+      { "label": "algokit-utils/crypto", "autogenerate": { "directory": "api/algokit-utils/crypto" } }
     ]
   }
 ]

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -1,4 +1,4 @@
 /**
- * @module Subpaths/abi
+ * @module algokit-utils/abi
  */
 export * from '@algorandfoundation/algokit-abi'

--- a/src/algo25/index.ts
+++ b/src/algo25/index.ts
@@ -1,4 +1,4 @@
 /**
- * @module Subpaths/algo25
+ * @module algokit-utils/algo25
  */
 export * from '@algorandfoundation/algokit-algo25'

--- a/src/algod-client/index.ts
+++ b/src/algod-client/index.ts
@@ -1,4 +1,4 @@
 /**
- * @module Subpaths/algod-client
+ * @module algokit-utils/algod-client
  */
 export * from '@algorandfoundation/algokit-algod-client'

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,4 +1,4 @@
 /**
- * @module Subpaths/common
+ * @module algokit-utils/common
  */
 export * from "@algorandfoundation/algokit-common";

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1,4 +1,4 @@
 /**
- * @module Subpaths/algokit-crypto
+ * @module algokit-utils/crypto
  */
 export * from '@algorandfoundation/algokit-crypto'

--- a/src/indexer-client/index.ts
+++ b/src/indexer-client/index.ts
@@ -1,5 +1,5 @@
 /**
- * @module Subpaths/indexer-client
+ * @module algokit-utils/indexer-client
  */
 export * from '@algorandfoundation/algokit-indexer-client'
 export * from './indexer-lookup'

--- a/src/kmd-client/index.ts
+++ b/src/kmd-client/index.ts
@@ -1,4 +1,4 @@
 /**
- * @module Subpaths/kmd-client
+ * @module algokit-utils/kmd-client
  */
 export * from '@algorandfoundation/algokit-kmd-client'

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,5 +1,5 @@
 /**
- * @module Subpaths/testing
+ * @module algokit-utils/testing
  */
 export * from '@algorandfoundation/algokit-testing'
 export * from './account'

--- a/src/transact/index.ts
+++ b/src/transact/index.ts
@@ -1,4 +1,4 @@
 /**
- * @module Subpaths/transact
+ * @module algokit-utils/transact
  */
 export * from '@algorandfoundation/algokit-transact'

--- a/src/transaction/index.ts
+++ b/src/transaction/index.ts
@@ -1,5 +1,5 @@
 /**
- * @module Subpaths/transaction
+ * @module algokit-utils/transaction
  */
 export * from './perform-transaction-composer-simulate'
 export * from './transaction'


### PR DESCRIPTION
## Summary

- Rename `@module` annotations from `Subpaths/*` to `algokit-utils/*` so generated API docs use consistent, cleaner paths
- Add remark plugin to strip trailing `/index/` from internal links (fixes 404s from starlight-typedoc generated URLs)
- Add missing `common` and `crypto` modules to typedoc entrypoints and sidebar
- Remove `transaction` from typedoc entrypoints (already covered by `algokit-utils` root module)