### PR TITLE
fix: properly match against new algod errors

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -13,5 +13,10 @@
     "active": true,
     "notes": "picomatch bundled inside npm in @semantic-release/npm - waiting for upstream fix",
     "expiry": "2026-06-01"
+  },
+  "1117683": {
+    "active": true,
+    "notes": "ip-address bundled inside npm",
+    "expiry": "2026-06-01"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5109,9 +5109,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -9644,9 +9644,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/src/app-client.ts
+++ b/src/app-client.ts
@@ -1397,7 +1397,7 @@ export class AppClient {
             const error = e as Error
             // For read-only calls with max opcode budget, fee issues should be rare
             // but we can still provide helpful error message if they occur
-            if (params.coverAppCallInnerTransactionFees && error && error.message && error.message.match(/fee too small/)) {
+            if (params.coverAppCallInnerTransactionFees && error && error.message && error.message.match(/too small/)) {
               throw Error(`Fees were too small. You may need to increase the transaction maxFee.`)
             }
             throw e

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1705,7 +1705,7 @@ export class TransactionComposer {
 
     // Handle any simulation failures
     if (groupResponse.failureMessage) {
-      if (analysisParams.coverAppCallInnerTransactionFees && groupResponse.failureMessage.includes('fee too small')) {
+      if (analysisParams.coverAppCallInnerTransactionFees && groupResponse.failureMessage.includes('too small')) {
         throw new Error(
           'Fees were too small to resolve execution info via simulate. You may need to increase an app call transaction maxFee.',
         )

--- a/src/transaction/transaction.spec.ts
+++ b/src/transaction/transaction.spec.ts
@@ -152,7 +152,7 @@ describe('transaction', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       const messageRegex = new RegExp(
-        `transaction ${txn2.txId()}: overspend \\(account ${testAccount}, data \\{.*\\}, tried to spend \\{9999999999999\\}\\)`,
+        `transaction ${txn2.txId()}: overspend \\(account ${testAccount}, data \\{.*\\}, tried to spend \\{?9999999`,
       )
       expect(e.traces[0].message).toMatch(messageRegex)
     }
@@ -201,7 +201,7 @@ describe('transaction', () => {
         coverAppCallInnerTransactionFees: false,
       } satisfies Parameters<(typeof appClient1)['send']['call']>[0]
 
-      await expect(async () => await appClient1.send.call(params)).rejects.toThrow(/fee too small/)
+      await expect(async () => await appClient1.send.call(params)).rejects.toThrow(/too small/)
     })
 
     test('does not alter fee when app call has no inners', async () => {
@@ -727,7 +727,7 @@ describe('transaction', () => {
             extraFee: undefined,
             suppressLog: true,
           }),
-      ).rejects.toThrowError(/fee too small/)
+      ).rejects.toThrowError(/too small/)
     }
   })
 })


### PR DESCRIPTION
algod 4.7 changed the fee error from this:

```go
return fmt.Errorf("fee too small %#v", cx.subtxns)
```

To this:

```go
return fmt.Errorf("group fee %s too small (need %s) %#v", groupPaid, groupFee, cx.subtxns)
```

Matching on `too small` allows us to capture both