### PR TITLE
ci: grant pages: write to publish_docs job to fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,13 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
 
   publish_docs:
+    name: Publish docs to GitHub Pages
     needs:
       - ci
       - check_docs
-    if: github.ref == 'refs/heads/release'
+    if: github.ref_name == 'release'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: algorandfoundation/algokit-shared-config/.github/workflows/publish-docs.yml@main


### PR DESCRIPTION
## Summary
The `publish_docs` job calls a reusable workflow that requests `pages: write`. The top-level `permissions:` block didn't list it, so it defaulted to `none` and the release run failed.