### PR TITLE
ci: pin action SHAs, tighten permissions and drop decoupling refs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: [main, decoupling]
+    branches: [main]
 
 permissions:
   contents: read
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
 

--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate bot token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app_token
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token }}
@@ -27,7 +27,7 @@ jobs:
         run: git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com" && git config --global user.name "engineering-ci[bot]"
 
       - name: Merge main -> release
-        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # v1.4.0
         with:
           type: now
           from_branch: main
@@ -35,7 +35,7 @@ jobs:
           github_token: ${{ steps.app_token.outputs.token }}
 
       - name: Merge release -> main
-        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # v1.4.0
         with:
           type: now
           from_branch: release

--- a/.github/workflows/publish-devportal-docs.yml
+++ b/.github/workflows/publish-devportal-docs.yml
@@ -3,7 +3,7 @@ name: Publish DevPortal Docs
 on:
   workflow_dispatch:
   push:
-    branches: [ci/add-publish-to-devportal-workflow] # change to decoupling, then main when ready
+    branches: [main]
     tags: ['v*']
 
 permissions:
@@ -13,13 +13,13 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           package_json_file: docs/package.json
 
@@ -30,6 +30,6 @@ jobs:
         run: npm run build
 
       - name: Publish DevPortal Docs
-        uses: algorandfoundation/devportal/.github/actions/publish-devportal-docs@ci/update-publish-devportal-docs-workflow
+        uses: algorandfoundation/devportal/.github/actions/publish-devportal-docs@release/ak-v4
         with:
           docs-dir: docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,12 @@ on:
     branches:
       - main
       - release
-      - decoupling
   workflow_dispatch:
 
 concurrency: release
 
 permissions:
-  contents: write
-  issues: read
-  id-token: write
+  contents: read
 
 jobs:
   ci:
@@ -47,14 +44,14 @@ jobs:
       id-token: write
     steps:
       - name: Generate bot token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app_token
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token }}
@@ -63,12 +60,12 @@ jobs:
         run: git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com" && git config --global user.name "engineering-ci[bot]"
 
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
 
       - name: Download built package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: package
           path: artifacts
@@ -89,9 +86,7 @@ jobs:
 
   publish_docs:
     name: Publish docs to GitHub Pages
-    needs:
-      - ci
-      - check_docs
+    needs: release
     if: github.ref_name == 'release'
     permissions:
       contents: read

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Note: If you prefer Python there's an equivalent [Python utility library](https:
 ## Quick Links
 
 - **New to AlgoKit?** Start with the [Quick Start Tutorial](./tutorials/quick-start.md)
-- **Building an app?** See [Concepts](./concepts/algorand-client.md) and [Examples](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples)
+- **Building an app?** See [Concepts](./concepts/algorand-client.md) and [Examples](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples)
 - **API Reference** - [Auto-generated docs](./api/README.md)
 - **Upgrading?** See [Migration Guides](./migration/v7-migration.md)
 
@@ -206,17 +206,17 @@ The library helps you interact with and develop against the Algorand blockchain 
 
 # Examples
 
-We maintain [runnable examples](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples) organized by feature:
+We maintain [runnable examples](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples) organized by feature:
 
-- **[AlgorandClient](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples/algorand_client)** - High-level API usage
-- **[Transact](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples/transact)** - Transaction construction
-- **[ABI](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples/abi)** - ABI encoding/decoding
-- **[Testing](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples/testing)** - Testing utilities
-- **[Algod Client](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples/algod_client)** - Node operations
-- **[Indexer Client](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples/indexer_client)** - Blockchain queries
-- **[KMD Client](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples/kmd_client)** - Key management
-- **[Algo25](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples/algo25)** - Mnemonic utilities
-- **[Common](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples/common)** - Utility functions
+- **[AlgorandClient](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples/algorand_client)** - High-level API usage
+- **[Transact](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples/transact)** - Transaction construction
+- **[ABI](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples/abi)** - ABI encoding/decoding
+- **[Testing](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples/testing)** - Testing utilities
+- **[Algod Client](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples/algod_client)** - Node operations
+- **[Indexer Client](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples/indexer_client)** - Blockchain queries
+- **[KMD Client](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples/kmd_client)** - Key management
+- **[Algo25](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples/algo25)** - Mnemonic utilities
+- **[Common](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples/common)** - Utility functions
 
 # Reference documentation
 

--- a/docs/src/content/docs/tutorials/README.md
+++ b/docs/src/content/docs/tutorials/README.md
@@ -69,4 +69,4 @@ npx tsx hello-algorand.ts
 - [AlgorandClient](../concepts/algorand-client.md) - Learn about the main entry point
 - [Account Management](../concepts/account.md) - Different ways to create and manage accounts
 - [Transaction Management](../concepts/transaction.md) - Build and send transactions
-- [Examples](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples) - Browse 100+ runnable examples
+- [Examples](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples) - Browse 100+ runnable examples

--- a/docs/src/content/docs/tutorials/quick-start.md
+++ b/docs/src/content/docs/tutorials/quick-start.md
@@ -70,4 +70,4 @@ npx tsx hello-algorand.ts
 - [AlgorandClient](../concepts/core/algorand-client) - Learn about the main entry point
 - [Account Management](../concepts/core/account) - Different ways to create and manage accounts
 - [Transaction Management](../concepts/core/transaction) - Build and send transactions
-- [Examples](https://github.com/algorandfoundation/algokit-utils-ts/tree/decoupling/examples) - Browse 100+ runnable examples
+- [Examples](https://github.com/algorandfoundation/algokit-utils-ts/tree/main/examples) - Browse 100+ runnable examples

--- a/package.json
+++ b/package.json
@@ -185,10 +185,6 @@
       },
       {
         "name": "release"
-      },
-      {
-        "name": "decoupling",
-        "prerelease": "alpha"
       }
     ],
     "plugins": [


### PR DESCRIPTION
## Summary

This PR makes a few related changes now that the `decoupling` work has landed on `main`:

1. **Hardens the CI workflows** by pinning all GitHub Actions to immutable commit SHAs and tightening workflow permissions to least-privilege.
2. **Removes leftover `decoupling` branch references** across CI triggers, release config, and docs links.
3. **Keeps the DevPortal docs current** by publishing the rolling `docs-latest` build on every push to `main`.

## Changes

### CI security hardening

- Pin all third-party and first-party actions to full commit SHAs (with `# vX` comments) instead of mutable tags in `pr.yml`, `prod_release.yml`, `publish-devportal-docs.yml`, and `release.yml`.
- Narrow top-level `permissions` in `release.yml` from `contents: write` / `issues: read` / `id-token: write` down to `contents: read` (jobs that need more grant it locally).
- Simplify the `publish_docs` job to depend on `release` only (instead of `ci` + `check_docs`).

### Decoupling branch cleanup

- Remove `decoupling` from PR trigger branches (`pr.yml`) and release push branches (`release.yml`).
- Drop the `decoupling` / `alpha` prerelease entry from the semantic-release config in `package.json`.
- Repoint docs example links from `tree/decoupling/examples` to `tree/main/examples` (`docs/README.md`, `tutorials/README.md`, `tutorials/quick-start.md`).
- Update `publish-devportal-docs.yml`: drop the temporary `ci/add-publish-to-devportal-workflow` push trigger and point the publish action at `release/ak-v4`.

### DevPortal docs publishing

- Add a `push: branches: [main]` trigger to `publish-devportal-docs.yml` so the rolling `docs-latest` pre-release is refreshed on every merge to `main`. Tag pushes (`v*`) continue to attach `devportal-docs.tar.gz` to the corresponding version release.

## Why

- Pinning actions to SHAs protects the supply chain against tag-retargeting attacks.
- Least-privilege permissions reduce the blast radius if a workflow or dependency is compromised.
- The `decoupling` branch is merged, so the references are dead and could trigger or publish from a branch that no longer exists.
- The DevPortal imports each library's "Latest" docs from the `docs-latest` release, which is only refreshed by non-tag runs. Without a `main` trigger, `docs-latest` would go stale and the portal would keep serving outdated docs.
