### PR TITLE
fix(transact): support empty access references

### DIFF
--- a/packages/transact/src/transactions/transaction-meta.ts
+++ b/packages/transact/src/transactions/transaction-meta.ts
@@ -337,12 +337,14 @@ class AppCallDataCodec extends Codec<AppCallTransactionFields | undefined, Recor
         if (box.appId && box.appId !== appId) {
           appIndex = ensure({ appId: box.appId })
         }
-        accessList.push({
-          b: {
-            i: numberCodec.encodeOptional(appIndex, format),
-            n: bytesCodec.encodeOptional(box.name, format),
-          },
-        })
+        const wireBox = {
+          i: numberCodec.encodeOptional(appIndex, format),
+          n: bytesCodec.encodeOptional(box.name, format),
+        }
+
+        // An empty ResourceRef is the canonical representation of additional
+        // box I/O budget. Do not wrap it in a non-canonical empty BoxRef.
+        accessList.push(wireBox.i === undefined && wireBox.n === undefined ? {} : { b: wireBox })
         continue
       }
     }
@@ -430,21 +432,23 @@ class AppCallDataCodec extends Codec<AppCallTransactionFields | undefined, Recor
         continue
       }
 
+      // Empty ResourceRefs are valid and contribute additional box I/O budget.
+      if (d === undefined && s === undefined && p === undefined && !h && !l && !b) {
+        result.push({ box: { appId: 0n, name: new Uint8Array() } })
+        continue
+      }
+
       // Box reference (b)
       if (b) {
         const boxAppIdx = (b.i ?? 0) as number
         const name = b.n as WireString | undefined
-
-        if (!name) {
-          throw new Error('Access list box reference is missing name')
-        }
 
         const boxAppId = boxAppIdx === 0 ? 0n : (wireResourceReferences[boxAppIdx - 1].p! as WireBigInt)
 
         result.push({
           box: {
             appId: bigIntCodec.decode(boxAppId, format),
-            name: bytesCodec.decode(name, format),
+            name: name === undefined ? new Uint8Array() : bytesCodec.decode(name, format),
           },
         })
         continue

--- a/packages/transact/tests/empty_access_reference.test.ts
+++ b/packages/transact/tests/empty_access_reference.test.ts
@@ -1,0 +1,49 @@
+import { Address, decodeMsgpack } from '@algorandfoundation/algokit-common'
+import { assert, describe, test } from 'vitest'
+import { OnApplicationComplete } from '../src/transactions/app-call'
+import { decodeTransaction, encodeTransactionRaw, Transaction, transactionCodec } from '../src/transactions/transaction'
+import { TransactionType } from '../src/transactions/transaction-type'
+
+const emptyReference = { box: { appId: 0n, name: new Uint8Array() } }
+const namedReference = { box: { appId: 0n, name: new TextEncoder().encode('weights') } }
+
+function appCall(accessReferences = [emptyReference, namedReference, emptyReference]): Transaction {
+  return new Transaction({
+    sender: Address.fromString('BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4'),
+    firstValid: 322575n,
+    lastValid: 322575n,
+    fee: 1000n,
+    genesisId: 'testnet-v1.0',
+    genesisHash: new Uint8Array(Buffer.from('SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=', 'base64')),
+    type: TransactionType.AppCall,
+    appCall: {
+      appId: 111n,
+      onComplete: OnApplicationComplete.NoOp,
+      accessReferences,
+    },
+  })
+}
+
+describe('Empty access list references', () => {
+  test('canonically encodes and decodes empty references', () => {
+    const encoded = encodeTransactionRaw(appCall())
+    const wireTransaction = decodeMsgpack(encoded, {
+      useMap: false,
+      rawBinaryStringKeys: false,
+      rawBinaryStringValues: true,
+    }) as unknown as { al: unknown[] }
+    assert.deepStrictEqual(wireTransaction.al, [{}, { b: { n: namedReference.box.name } }, {}])
+
+    const decoded = decodeTransaction(encoded)
+    assert.deepStrictEqual(decoded.appCall?.accessReferences, [emptyReference, namedReference, emptyReference])
+    assert.deepStrictEqual(encodeTransactionRaw(decoded), encoded)
+  })
+
+  test('decodes a non-canonical empty box reference for compatibility', () => {
+    const encoded = transactionCodec.encode(appCall([]), 'msgpack')
+    encoded.al = [{ b: {} }]
+
+    const decoded = transactionCodec.decode(encoded, 'msgpack')
+    assert.deepStrictEqual(decoded.appCall?.accessReferences, [emptyReference])
+  })
+})


### PR DESCRIPTION
## Summary

- encode empty access-list resource references using the canonical empty map representation
- preserve canonical empty references when decoding transactions
- decode the previous non-canonical empty box representation for compatibility
- add focused wire-level and round-trip regression tests

## Root cause

go-algorand permits an empty ResourceRef in txn.Access to request additional box I/O budget. The transact codec represented that resource in memory as a box with app ID zero and an empty name, but encoded it as a nested empty BoxRef. The same codec then rejected the representation because the omitted box name was treated as missing.

The nested empty BoxRef and canonical empty ResourceRef produce different MessagePack bytes. Signing the non-canonical bytes can therefore produce a payload that does not match the transaction encoding used by algod for signature verification.

## Impact

Empty access references now encode canonically, survive decode/encode round trips, and no longer fail with "Access list box reference is missing name". Existing callers can continue using the current in-memory empty-box sentinel.

## Validation

- focused empty access-reference tests: 2 passed
- transact TypeScript check
- transact ESLint check
- Prettier check
- full repository build
- independent parity check against algosdk 3.6.0: identical 153-byte transaction encoding and identical transaction ID
