### PR TITLE
feat: throw helpful error on duplicate transactions in composer

### DIFF
--- a/src/types/composer.spec.ts
+++ b/src/types/composer.spec.ts
@@ -1,5 +1,8 @@
+import algosdk from 'algosdk'
 import { beforeEach, describe, expect, test } from 'vitest'
+import { microAlgo } from '../amount'
 import { algorandFixture } from '../testing'
+import { TransactionComposer } from './composer'
 
 describe('TransactionComposer', () => {
   const fixture = algorandFixture()
@@ -63,5 +66,66 @@ describe('TransactionComposer', () => {
 
       await expect(composer.send()).rejects.toThrow('ASSET MISSING!')
     })
+  })
+})
+
+describe('TransactionComposer duplicate detection', () => {
+  const fixedSuggestedParams = (): algosdk.SuggestedParams => ({
+    fee: 1000n,
+    firstValid: 1000n,
+    lastValid: 2000n,
+    genesisHash: new Uint8Array(32),
+    genesisID: 'testnet-v1.0',
+    minFee: 1000n,
+    flatFee: true,
+  })
+
+  const newComposer = () =>
+    new TransactionComposer({
+      algod: {} as algosdk.Algodv2,
+      getSuggestedParams: async () => fixedSuggestedParams(),
+      getSigner: () => algosdk.makeEmptyTransactionSigner(),
+    })
+
+  test('throws a helpful error when the group contains identical transactions', async () => {
+    const account = algosdk.generateAccount()
+    const composer = newComposer()
+
+    composer.addPayment({
+      sender: account.addr,
+      receiver: account.addr,
+      amount: microAlgo(1),
+    })
+    composer.addPayment({
+      sender: account.addr,
+      receiver: account.addr,
+      amount: microAlgo(1),
+    })
+
+    await expect(composer.build()).rejects.toThrow(/duplicate transactions/)
+    await expect(composer.buildTransactions()).rejects.toThrow(/suggestedParams are cached/)
+    await expect(composer.build()).rejects.toThrow(/note, lease, validityWindow/)
+  })
+
+  test('allows identical-looking payments when a differentiating note is provided', async () => {
+    const account = algosdk.generateAccount()
+    const composer = newComposer()
+
+    composer.addPayment({
+      sender: account.addr,
+      receiver: account.addr,
+      amount: microAlgo(1),
+      note: 'a',
+    })
+    composer.addPayment({
+      sender: account.addr,
+      receiver: account.addr,
+      amount: microAlgo(1),
+      note: 'b',
+    })
+
+    const { transactions } = await composer.build()
+    expect(transactions).toHaveLength(2)
+    expect(transactions[0].txn.txID()).not.toEqual(transactions[1].txn.txID())
   })
 })

--- a/src/types/composer.spec.ts
+++ b/src/types/composer.spec.ts
@@ -105,6 +105,8 @@ describe('TransactionComposer duplicate detection', () => {
     await expect(composer.build()).rejects.toThrow(/duplicate transactions/)
     await expect(composer.buildTransactions()).rejects.toThrow(/suggestedParams are cached/)
     await expect(composer.build()).rejects.toThrow(/note, lease, validityWindow/)
+    await expect(composer.build()).rejects.toThrow(/0-based indexes 0 and 1/)
+    await expect(composer.build()).rejects.toThrow(/setSuggestedParamsCacheTimeout\(0\)/)
   })
 
   test('allows identical-looking payments when a differentiating note is provided', async () => {

--- a/src/types/composer.ts
+++ b/src/types/composer.ts
@@ -1884,7 +1884,6 @@ export class TransactionComposer {
     }
   }
 
-
   /**
    * Reject transaction groups that contain more than one identical transaction.
    * Identical transactions share a transaction ID (same fields including first/last valid).
@@ -1897,10 +1896,10 @@ export class TransactionComposer {
       const firstIndex = firstIndexById.get(txId)
       if (firstIndex !== undefined) {
         throw new Error(
-          `Transaction group contains duplicate transactions (same transaction ID) at indexes ${firstIndex} and ${index} (txID: ${txId}). ` +
+          `Transaction group contains duplicate transactions (same transaction ID) at 0-based indexes ${firstIndex} and ${index} (txID: ${txId}). ` +
             `This often happens when suggestedParams are cached, so identical calls get the same firstValid/lastValid rounds. ` +
             `Make each transaction unique (for example a different note, lease, validityWindow, firstValidRound, or lastValidRound). ` +
-            `If you are using AlgorandClient, refresh suggested params with setSuggestedParamsCacheTimeout(0) or wait for the cache to expire and call getSuggestedParams again.`,
+            `If you are using AlgorandClient, refresh suggested params with setSuggestedParamsCacheTimeout(0).`,
         )
       }
       firstIndexById.set(txId, index)

--- a/src/types/composer.ts
+++ b/src/types/composer.ts
@@ -1884,6 +1884,29 @@ export class TransactionComposer {
     }
   }
 
+
+  /**
+   * Reject transaction groups that contain more than one identical transaction.
+   * Identical transactions share a transaction ID (same fields including first/last valid).
+   * This commonly happens when suggestedParams are cached and the same call is composed multiple times.
+   */
+  private assertNoDuplicateTransactions(transactions: algosdk.Transaction[]): void {
+    const firstIndexById = new Map<string, number>()
+    for (let index = 0; index < transactions.length; index++) {
+      const txId = transactions[index].txID()
+      const firstIndex = firstIndexById.get(txId)
+      if (firstIndex !== undefined) {
+        throw new Error(
+          `Transaction group contains duplicate transactions (same transaction ID) at indexes ${firstIndex} and ${index} (txID: ${txId}). ` +
+            `This often happens when suggestedParams are cached, so identical calls get the same firstValid/lastValid rounds. ` +
+            `Make each transaction unique (for example a different note, lease, validityWindow, firstValidRound, or lastValidRound). ` +
+            `If you are using AlgorandClient, refresh suggested params with setSuggestedParamsCacheTimeout(0) or wait for the cache to expire and call getSuggestedParams again.`,
+        )
+      }
+      firstIndexById.set(txId, index)
+    }
+  }
+
   private async buildTxnWithSigner(txn: Txn, suggestedParams: algosdk.SuggestedParams): Promise<TransactionWithSignerAndContext[]> {
     if (txn.type === 'txnWithSigner') {
       return [
@@ -1950,6 +1973,8 @@ export class TransactionComposer {
       }
     }
 
+    this.assertNoDuplicateTransactions(transactions)
+
     return { transactions, methodCalls, signers }
   }
 
@@ -1983,6 +2008,8 @@ export class TransactionComposer {
       for (const txn of this.txns) {
         txnWithSigners.push(...(await this.buildTxnWithSigner(txn, suggestedParams)))
       }
+
+      this.assertNoDuplicateTransactions(txnWithSigners.map(({ txn }) => txn))
 
       // Add all of the transactions to the underlying ATC
       const methodCalls = new Map<number, algosdk.ABIMethod>()


### PR DESCRIPTION
## Summary
- Detects identical transaction IDs within a composed group in `build()` and `buildTransactions()`.
- Throws a descriptive error that explains the common `suggestedParams` cache cause and how to make each txn unique (`note`, `lease`, `validityWindow`, rounds, or refresh params).
- Adds unit tests covering the failure path and the successful differentiated-note path.

## Context
Fixes #366. Duplicate transactions are easy to create accidentally when `suggestedParams` are cached (same first/last valid), e.g. multiple identical gas/app calls in one group. Today the network rejects the group with a less actionable error; this fails early with guidance.

## Validation
```bash
npx vitest run src/types/composer.spec.ts -t "duplicate"
npx tsc --noEmit
npx eslint src/types/composer.ts src/types/composer.spec.ts
```