### PR TITLE
Docs: Rewrite Assets concept page with runnable examples

### DIFF
--- a/docs/src/content/docs/concepts/asset.mdx
+++ b/docs/src/content/docs/concepts/asset.mdx
@@ -1,333 +1,169 @@
 ---
-title: "Assets"
+title: 'Assets'
+description: 'Algorand Standard Assets are created, held, and moved by the Algorand ledger itself, and AlgoKit Utils TypeScript exposes every asset operation as a typed params object sent through the Algorand client.'
 ---
 
-The Algorand Standard Asset (asset) management functions include creating, opting in and transferring assets, which are fundamental to asset interaction in a blockchain environment.
-
-To see some usage examples check out the [automated tests](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/algorand-client.asset.spec.ts).
-
-## `AssetManager`
-
-The `AssetManager` is a class that is used to manage asset information.
-
-To get an instance of `AssetManager`, you can use either [`AlgorandClient`](/algokit-utils-ts/capabilities/algorand-client/) via `algorand.asset` or instantiate it directly:
-
-```typescript
-import { AssetManager } from '@algorandfoundation/algokit-utils/types/asset-manager'
-import {TransactionComposer } from '@algorandfoundation/algokit-utils/types/composer'
-
-const assetManager = new AssetManager(algod, () => new TransactionComposer({algod, () => signer, () => suggestedParams}))
-```
-
-## Creation
-
-To create an asset you can use `algorand.send.assetCreate(params)` (immediately send a single asset creation transaction), `algorand.createTransaction.assetCreate(params)` (construct an asset creation transaction), or `algorand.newGroup().addAssetCreate(params)` (add asset creation to a group of transactions) per [`AlgorandClient`](/algokit-utils-ts/capabilities/algorand-client/) [transaction semantics](/algokit-utils-ts/capabilities/algorand-client/#creating-and-issuing-transactions).
-
-The base type for specifying an asset creation transaction is `AssetCreateParams`, which has the following parameters in addition to the [common transaction parameters](/algokit-utils-ts/capabilities/algorand-client/#transaction-parameters):
-
-- `total: bigint` - The total amount of the smallest divisible (decimal) unit to create. For example, if `decimals` is, say, 2, then for every 100 `total` there would be 1 whole unit. This field can only be specified upon asset creation.
-- `decimals: number` - The amount of decimal places the asset should have. If unspecified then the asset will be in whole units (i.e. `0`). If 0, the asset is not divisible. If 1, the base unit of the asset is in tenths, and so on up to 19 decimal places. This field can only be specified upon asset creation.
-- `assetName?: string` - The optional name of the asset. Max size is 32 bytes. This field can only be specified upon asset creation.
-- `unitName?: string` - The optional name of the unit of this asset (e.g. ticker name). Max size is 8 bytes. This field can only be specified upon asset creation.
-- `url?: string` - Specifies an optional URL where more information about the asset can be retrieved. Max size is 96 bytes. This field can only be specified upon asset creation.
-- `metadataHash?: string | Uint8Array` - 32-byte hash of some metadata that is relevant to your asset and/or asset holders. The format of this metadata is up to the application. This field can only be specified upon asset creation.
-- `defaultFrozen?: boolean` - Whether to freeze holdings for this asset by default. Defaults to `false`. If `true` then for anyone apart from the creator to hold the asset it needs to be unfrozen using an asset freeze transaction from the `freeze` account, which must be set on creation. This field can only be specified upon asset creation.
-- `manager?: string` - The address of the optional account that can manage the configuration of the asset and destroy it. The configuration fields it can change are `manager`, `reserve`, `clawback`, and `freeze`. If not set (`undefined` or `""`) at asset creation or subsequently set to empty by the `manager` the asset becomes permanently immutable.
-- `reserveAccount?: string` - The address of the optional account that holds the reserve (uncirculated supply) units of the asset. This address has no specific authority in the protocol itself and is informational only. Some standards like [ARC-19](https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0019.md) rely on this field to hold meaningful data. It can be used in the case where you want to signal to holders of your asset that the uncirculated units of the asset reside in an account that is different from the default creator account. If not set (`undefined` or `""`) at asset creation or subsequently set to empty by the manager the field is permanently empty.
-- `freezeAccount?: string` - The address of the optional account that can be used to freeze or unfreeze holdings of this asset for any account. If empty, freezing is not permitted. If not set (`undefined` or `""`) at asset creation or subsequently set to empty by the manager the field is permanently empty.
-- `clawbackAccount?: string` - The address of the optional account that can clawback holdings of this asset from any account. **This field should be used with caution** as the clawback account has the ability to **unconditionally take assets from any account**. If empty, clawback is not permitted. If not set (`undefined` or `""`) at asset creation or subsequently set to empty by the manager the field is permanently empty.
-
-### Examples
-
-```typescript
-// Basic example
-const result = await algorand.send.assetCreate({ sender: 'CREATORADDRESS', total: 100n })
-const createdAssetId = result.assetId
-
-// Advanced example
-await algorand.send.assetCreate({
-  sender: 'CREATORADDRESS',
-  total: 100n,
-  decimals: 2,
-  assetName: 'asset',
-  unitName: 'unit',
-  url: 'url',
-  metadataHash: 'metadataHash',
-  defaultFrozen: false,
-  manager: 'MANAGERADDRESS',
-  reserve: 'RESERVEADDRESS',
-  freeze: 'FREEZEADDRESS',
-  clawback: 'CLAWBACKADDRESS',
-  lease: 'lease',
-  note: 'note',
-  // You wouldn't normally set this field
-  firstValidRound: 1000n,
-  validityWindow: 10,
-  extraFee: (1000).microAlgo(),
-  staticFee: (1000).microAlgo(),
-  // Max fee doesn't make sense with extraFee AND staticFee
-  //  already specified, but here for completeness
-  maxFee: (3000).microAlgo(),
-  // Signer only needed if you want to provide one,
-  //  generally you'd register it with AlgorandClient
-  //  against the sender and not need to pass it in
-  signer: transactionSigner,
-  maxRoundsToWaitForConfirmation: 5,
-  suppressLog: true,
-})
-```
-
-## Reconfigure
-
-If you have a `manager` address set on an asset, that address can send a reconfiguration transaction to change the `manager`, `reserve`, `freeze` and `clawback` fields of the asset if they haven't been set to empty.
-
-> [!WARNING]
-> If you issue a reconfigure transaction and don't set the _existing_ values for any of the below fields then that field will be permanently set to empty.
-
-To reconfigure an asset you can use `algorand.send.assetConfig(params)` (immediately send a single asset config transaction), `algorand.createTransaction.assetConfig(params)` (construct an asset config transaction), or `algorand.newGroup().addAssetConfig(params)` (add asset config to a group of transactions) per [`AlgorandClient`](/algokit-utils-ts/capabilities/algorand-client/) [transaction semantics](/algokit-utils-ts/capabilities/algorand-client/#creating-and-issuing-transactions).
-
-The base type for specifying an asset creation transaction is `AssetConfigParams`, which has the following parameters in addition to the [common transaction parameters](/algokit-utils-ts/capabilities/algorand-client/#transaction-parameters):
-
-- `assetId: bigint` - ID of the asset to reconfigure
-- `manager: string | undefined` - The address of the optional account that can manage the configuration of the asset and destroy it. The configuration fields it can change are `manager`, `reserve`, `clawback`, and `freeze`. If not set (`undefined` or `""`) the asset will become permanently immutable.
-- `reserve?: string` - The address of the optional account that holds the reserve (uncirculated supply) units of the asset. This address has no specific authority in the protocol itself and is informational only. Some standards like [ARC-19](https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0019.md) rely on this field to hold meaningful data. It can be used in the case where you want to signal to holders of your asset that the uncirculated units of the asset reside in an account that is different from the default creator account. If not set (`undefined` or `""`) the field will become permanently empty.
-- `freeze?: string` - The address of the optional account that can be used to freeze or unfreeze holdings of this asset for any account. If empty, freezing is not permitted. If not set (`undefined` or `""`) the field will become permanently empty.
-- `clawback?: string` - The address of the optional account that can clawback holdings of this asset from any account. **This field should be used with caution** as the clawback account has the ability to **unconditionally take assets from any account**. If empty, clawback is not permitted. If not set (`undefined` or `""`) the field will become permanently empty.
-
-### Examples
-
-```typescript
-// Basic example
-
-await algorand.send.assetConfig({ sender: 'MANAGERADDRESS', assetId: 123456n, manager: 'MANAGERADDRESS' })
-
-// Advanced example
-
-await algorand.send.assetConfig({
-  sender: 'MANAGERADDRESS',
-  assetId: 123456n,
-  manager: 'MANAGERADDRESS',
-  reserve: 'RESERVEADDRESS',
-  freeze: 'FREEZEADDRESS',
-  clawback: 'CLAWBACKADDRESS',
-  lease: 'lease',
-  note: 'note',
-  // You wouldn't normally set this field
-  firstValidRound: 1000n,
-  validityWindow: 10,
-  extraFee: (1000).microAlgo(),
-  staticFee: (1000).microAlgo(),
-  // Max fee doesn't make sense with extraFee AND staticFee
-  //  already specified, but here for completeness
-  maxFee: (3000).microAlgo(),
-  // Signer only needed if you want to provide one,
-  //  generally you'd register it with AlgorandClient
-  //  against the sender and not need to pass it in
-  signer: transactionSigner,
-  maxRoundsToWaitForConfirmation: 5,
-  suppressLog: true,
-})
-```
-
-## Transfer
-
-To transfer unit(s) of an asset between accounts you can use `algorand.send.assetTransfer(params)` (immediately send a single asset transfer transaction), `algorand.createTransaction.assetTransfer(params)` (construct an asset transfer transaction), or `algorand.newGroup().addAssetTransfer(params)` (add asset transfer to a group of transactions) per [`AlgorandClient`](/algokit-utils-ts/capabilities/algorand-client/) [transaction semantics](/algokit-utils-ts/capabilities/algorand-client/#creating-and-issuing-transactions).
-
-**Note:** For an account to receive an asset it needs to have [opted-in](#opt-inout).
-
-The base type for specifying an asset transfer transaction is `AssetTransferParams`, which has the following parameters in addition to the [common transaction parameters](/algokit-utils-ts/capabilities/algorand-client/#transaction-parameters):
-
-- `assetId: bigint` - ID of the asset to transfer.
-- `amount: bigint` - Amount of the asset to transfer (in smallest divisible (decimal) units).
-- `receiver: string` - The address of the account that will receive the asset unit(s).
-- `clawbackTarget?: string` - Optional address of an account to clawback the asset from. Requires the sender to be the clawback account. **Warning:** Be careful with this parameter as it can lead to unexpected loss of funds if not used correctly.
-- `closeAssetTo?: string` - Optional address of an account to close the asset position to. **Warning:** Be careful with this parameter as it can lead to loss of funds if not used correctly.
-
-### Examples
-
-```typescript
-// Basic example
-
-await algorand.send.assetTransfer({sender: 'HOLDERADDRESS', assetId: 123456n, amount: 1n, receiver: 'RECEIVERADDRESS' })
-
-// Advanced example (with clawback and close asset to)
-
-await algorand.send.assetTransfer({
-  sender: 'CLAWBACKADDRESS',
-  assetId: 123456n,
-  amount: 1n,
-  receiver: 'RECEIVERADDRESS',
-  clawbackTarget: 'HOLDERADDRESS',
-  // This field needs to be used with caution
-  closeAssetTo: 'ADDRESSTOCLOSETO'
-  lease: 'lease',
-  note: 'note',
-  // You wouldn't normally set this field
-  firstValidRound: 1000n,
-  validityWindow: 10,
-  extraFee: (1000).microAlgo(),
-  staticFee: (1000).microAlgo(),
-  // Max fee doesn't make sense with extraFee AND staticFee
-  //  already specified, but here for completeness
-  maxFee: (3000).microAlgo(),
-  // Signer only needed if you want to provide one,
-  //  generally you'd register it with AlgorandClient
-  //  against the sender and not need to pass it in
-  signer: transactionSigner,
-  maxRoundsToWaitForConfirmation: 5,
-  suppressLog: true,
-})
-```
-
-## Opt-in/out
-
-Before an account can receive a specific asset, it must [`opt-in`](https://dev.algorand.co/concepts/assets/asset-operations/#opting-in-and-out-of-assets) to receive it. An opt-in transaction places an asset holding of 0 into the account and increases the [minimum balance](https://dev.algorand.co/concepts/smart-contracts/costs-constraints#mbr) of that account by [100,000 microAlgos](https://dev.algorand.co/concepts/assets/overview/).
-
-An account can opt out of an asset at any time by closing out it's asset position to another account (usually to the asset creator). This means that the account will no longer hold the asset, and the account will no longer be able to receive the asset. The account also recovers the Minimum Balance Requirement for the asset (100,000 microAlgos).
-
-When opting-out you generally want to be careful to ensure you have a zero-balance otherwise you will forfeit the balance you do have. AlgoKit Utils can protect you from making this mistake by checking you have a zero-balance before issuing the opt-out transaction. You can turn this check off if you want to avoid the extra calls to Algorand and are confident in what you are doing.
-
-AlgoKit Utils gives you functions that allow you to do opt-ins and opt-outs in bulk or as a single operation. The bulk operations give you less control over the sending semantics as they automatically send the transactions to Algorand in the most optimal way using transaction groups of 16 at a time.
-
-### `assetOptIn`
-
-To opt-in to an asset you can use `algorand.send.assetOptIn(params)` (immediately send a single asset opt-in transaction), `algorand.createTransaction.assetOptIn(params)` (construct an asset opt-in transaction), or `algorand.newGroup().addAssetOptIn(params)` (add asset opt-in to a group of transactions) per [`AlgorandClient`](/algokit-utils-ts/capabilities/algorand-client/) [transaction semantics](/algokit-utils-ts/capabilities/algorand-client/#creating-and-issuing-transactions).
-
-The base type for specifying an asset opt-in transaction is `AssetOptInParams`, which has the following parameters in addition to the [common transaction parameters](/algokit-utils-ts/capabilities/algorand-client/#transaction-parameters):
-
-- `assetId: bigint` - The ID of the asset that will be opted-in to
-
-```typescript
-// Basic example
-
-await algorand.send.assetOptIn({ sender: 'SENDERADDRESS', assetId: 123456n })
-
-// Advanced example
-
-await algorand.send.assetOptIn({
-  sender: 'SENDERADDRESS',
-  assetId: 123456n,
-  lease: 'lease',
-  note: 'note',
-  // You wouldn't normally set this field
-  firstValidRound: 1000n,
-  validityWindow: 10,
-  extraFee: (1000).microAlgo(),
-  staticFee: (1000).microAlgo(),
-  // Max fee doesn't make sense with extraFee AND staticFee
-  //  already specified, but here for completeness
-  maxFee: (3000).microAlgo(),
-  // Signer only needed if you want to provide one,
-  //  generally you'd register it with AlgorandClient
-  //  against the sender and not need to pass it in
-  signer: transactionSigner,
-  maxRoundsToWaitForConfirmation: 5,
-  suppressLog: true,
-})
-```
-
-### `assetOptOut`
-
-To opt-out to an asset you can use `algorand.send.assetOptOut(params)` (immediately send a single asset opt-out transaction), `algorand.createTransaction.assetOptOut(params)` (construct an asset opt-out transaction), or `algorand.newGroup().addAssetOptOut(params)` (add asset opt-out to a group of transactions) per [`AlgorandClient`](/algokit-utils-ts/capabilities/algorand-client/) [transaction semantics](/algokit-utils-ts/capabilities/algorand-client/#creating-and-issuing-transactions).
-
-The base type for specifying an asset opt-out transaction is `AssetOptOutParams`, which has the following parameters in addition to the [common transaction parameters](/algokit-utils-ts/capabilities/algorand-client/#transaction-parameters):
-
-- `assetId: bigint` - The ID of the asset that will be opted-out of
-- `creator: string` - The address of the asset creator account to close the asset position to (any remaining asset units will be sent to this account).
-
-If you are using the `send` variant then there is an additional parameter:
-
-- `ensureZeroBalance: boolean` - Whether or not to check if the account has a zero balance first or not. If this is set to `true` and the account has an asset balance it will throw an error. If this is set to `false` and the account has an asset balance it will lose those assets to the asset creator.
-
-> !WARNING]
-> If you are using the `transaction` or `addAssetOptOut` variants then you need to take responsibility to ensure the asset holding balance is `0` to avoid losing assets.
-
-```typescript
-// Basic example (without creator)
-
-await algorand.send.assetOptOut({ sender: 'SENDERADDRESS', assetId: 123456n, ensureZeroBalance: true })
-
-// Basic example (with creator)
-
-await algorand.send.assetOptOut({ sender: 'SENDERADDRESS', creator: 'CREATORADDRESS', assetId: 123456n, ensureZeroBalance: true })
-
-// Advanced example
-
-await algorand.send.assetOptOut({
-  sender: 'SENDERADDRESS',
-  assetId: 123456n,
-  creator: 'CREATORADDRESS',
-  ensureZeroBalance: true,
-  lease: 'lease',
-  note: 'note',
-  // You wouldn't normally set this field
-  firstValidRound: 1000n,
-  validityWindow: 10,
-  extraFee: (1000).microAlgo(),
-  staticFee: (1000).microAlgo(),
-  // Max fee doesn't make sense with extraFee AND staticFee
-  //  already specified, but here for completeness
-  maxFee: (3000).microAlgo(),
-  // Signer only needed if you want to provide one,
-  //  generally you'd register it with AlgorandClient
-  //  against the sender and not need to pass it in
-  signer: transactionSigner,
-  maxRoundsToWaitForConfirmation: 5,
-  suppressLog: true,
-})
-```
-
-### `asset.bulkOptIn`
-
-The [`asset.bulkOptIn` function facilitates the opt-in process for an account to multiple assets, allowing the account to receive and hold those assets.
-
-```typescript
-// Basic example
-
-algorand.asset.bulkOptIn('ACCOUNTADDRESS', 12345n, 67890n])
-
-// Advanced example
-
-algorand.asset.bulkOptIn('ACCOUNTADDRESS', [12345n, 67890n], {
-  maxFee: (1000).microAlgo(),
-  suppressLog: true,
-})
-```
-
-### `asset.bulkOptOut`
-
-The [`asset.bulkOptOut` function facilitates the opt-out process for an account from multiple assets, permitting the account to discontinue holding a group of assets.
-
-```typescript
-// Basic example
-
-algorand.asset.bulkOptOut('ACCOUNTADDRESS', [12345n, 67890n])
-
-// Advanced example
-
-algorand.asset.bulkOptOut('ACCOUNTADDRESS', [12345n, 67890n], {
-  ensureZeroBalance: true,
-  maxFee: (1000).microAlgo(),
-  suppressLog: true,
-})
-```
-
-## Get information
-
-### Getting current parameters for an asset
-
-You can get the current parameters of an asset from algod by using `algorand.asset.getById(assetId)`.
-
-```typescript
-const assetInfo = await assetManager.getById(12353n)
-```
-
-### Getting current holdings of an asset for an account
-
-You can get the current holdings of an asset for a given account from algod by using `algorand.asset.getAccountInformation(accountAddress, assetId)`.
-
-```typescript
-const address = 'XBYLS2E6YI6XXL5BWCAMOA4GTWHXWENZMX5UHXMRNWWUQ7BXCY5WC5TEPA'
-const assetId = 123345n
-const accountInfo = await algorand.asset.getAccountInformation(address, assetId)
-```
+import { CardGrid, LinkCard } from '@astrojs/starlight/components'
+import RemoteCode from '/src/components/RemoteCode.astro'
+
+Algorand Standard Assets (ASAs) are a primitive of the Algorand network. Tokens are created, held, and moved by the ledger itself, and every asset operation is an ordinary transaction. AlgoKit Utils reflects this directly. Each operation is a typed params object (`AssetCreateParams`, `AssetTransferParams`, and so on) passed to `algorand.send`, exactly like a payment. What is asset-specific lives in `algorand.asset`, the `AssetManager`: queries over assets and holdings, plus bulk opt-in and opt-out helpers that add group batching and safety checks single transactions don't provide.
+
+This page walks through the asset lifecycle from creation to destruction. For the protocol rules themselves — the control roles, the opt-in requirement, freeze and clawback semantics — see the [Assets overview](https://dev.algorand.co/concepts/assets/overview/) and [Asset Operations](https://dev.algorand.co/concepts/assets/asset-operations/) pages on the Algorand Developer Portal.
+
+Operations whose effects cannot be undone are collected in [Safety Considerations](#safety-considerations).
+
+## Create an Asset
+
+Creating an ASA raises the creator's minimum balance requirement by 0.1 Algo, so any account able to cover that increase and the transaction fee can create one. The sender becomes the asset's creator, and the entire supply starts in their account. `algorand.send.assetCreate` builds, signs, and submits the transaction, and the result carries the new asset's ID.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="CREATE_ASSET"
+  lang="ts"
+  frame="none"
+/>
+
+## Opt In and Out of Assets
+
+An account cannot receive or hold units of an asset it has not opted into. Opting in creates an empty holding for that asset; opting out closes it again. Both directions have a bulk helper on `algorand.asset` for acting on several assets in one call.
+
+### Opt In
+
+Each holding raises the account's minimum balance requirement by 0.1 Algo, so an account pays for the assets it chooses to hold. The opting-in account signs and sends the transaction itself.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="OPT_IN_ASSET"
+  lang="ts"
+  frame="none"
+/>
+
+To opt into several assets at once, `algorand.asset.bulkOptIn(...)` takes a list of asset IDs and batches the opt-in transactions into atomic groups of up to 16, the protocol's transaction group limit.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="BULK_OPT_IN_ASSET"
+  lang="ts"
+  frame="none"
+/>
+
+### Opt Out
+
+Closing a holding releases the 0.1 Algo it reserved. `AssetOptOutParams` takes the asset's `creator`, which receives any units still held — so `algorand.send.assetOptOut` checks the balance is zero before submitting, unless `ensureZeroBalance: false` says otherwise.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="OPT_OUT_ASSET"
+  lang="ts"
+  frame="none"
+/>
+
+`algorand.asset.bulkOptOut(...)` closes several holdings the same way, with the same zero-balance check applied to each.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="BULK_OPT_OUT_ASSET"
+  lang="ts"
+  frame="none"
+/>
+
+## Transfer an Asset
+
+A transfer moves units between two accounts that have both opted into the asset. The sender needs at least the amount being sent, and neither holding may be frozen.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="TRANSFER_ASSET"
+  lang="ts"
+  frame="none"
+/>
+
+## Access Control
+
+An asset carries four optional authority addresses: `manager`, `reserve`, `freeze`, and `clawback`. Each is assigned when the asset is created, and an address left empty at creation can never be filled in later — an asset created without a `freeze` address can never be frozen.
+
+### Reconfigure an Asset
+
+The `manager` can reassign any of the four addresses. `AssetConfigParams` replaces all of them at once rather than patching one field, so an address left unset is submitted as empty and the role is cleared for good. Pass every address you intend to keep.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="RECONFIGURE_ASSET"
+  lang="ts"
+  frame="none"
+/>
+
+### Freeze or Unfreeze Assets
+
+The `freeze` address can stop a single account from moving a single asset. `AssetFreezeParams` names the account and carries a `frozen` flag, so the same call reverses the freeze by passing `false`.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="FREEZE_ASSET"
+  lang="ts"
+  frame="none"
+/>
+
+### Clawback Assets
+
+The `clawback` address can move units out of any opted-in account without the holder's consent. There is no dedicated params type for it: a clawback is an `AssetTransferParams` sent by the clawback address, with `clawbackTarget` naming the account the units come from.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="CLAWBACK_ASSET"
+  lang="ts"
+  frame="none"
+/>
+
+## Asset Queries
+
+Beyond the bulk helpers above, the `AssetManager` on `algorand.asset` answers two questions — what an asset is, and what an account holds:
+
+- `algorand.asset.getById(assetId)` returns the asset's parameters (total supply, decimals, unit name, control addresses, and so on).
+- `algorand.asset.getAccountInformation(sender, assetId)` returns the given account's holding for the asset.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="ASSET_MANAGER_QUERIES"
+  lang="ts"
+  frame="none"
+/>
+
+## Destroy an Asset
+
+Destroying an asset removes it from the ledger and releases the creator's 0.1 Algo. The `manager` sends the transaction, and every unit must be back in the creator's account first — an asset with units still circulating cannot be destroyed.
+
+<RemoteCode
+  src="https://raw.githubusercontent.com/algorandfoundation/algokit-utils-ts/main/examples/concepts/assets.algo.ts"
+  snippet="DESTROY_ASSET"
+  lang="ts"
+  frame="none"
+/>
+
+## Safety Considerations
+
+Three asset behaviors deserve attention because their effects are difficult or impossible to reverse. The [Asset Operations](https://dev.algorand.co/concepts/assets/asset-operations/) page on the Algorand Developer Portal describes the protocol-level rules in full; the notes below focus on library-level behavior.
+
+- **Reconfiguration can permanently clear control addresses.** A partial reconfiguration that omits a role removes that role from the asset for the remainder of its lifetime.
+- **Clawback removes assets from another account without the holder's consent.** A clawback is a transfer signed by the clawback authority, which can move assets out of any opted-in account without further approval from the holder.
+- **Opting out with a remaining balance can result in losing those assets.** Both `algorand.send.assetOptOut` and `algorand.asset.bulkOptOut` verify a zero balance before submission by default (`ensureZeroBalance: true`). With that check disabled, the opt-out proceeds even when the account still holds units of the asset, and those units are forfeited on submission.
+
+## What's Next
+
+<CardGrid>
+  <LinkCard
+    title="Algorand Client"
+    href="/algokit-utils-ts/concepts/algorand-client/"
+    description="The entry point that provides the send and asset surfaces used on this page"
+  />
+  <LinkCard
+    title="Transactions"
+    href="/algokit-utils-ts/concepts/transaction/"
+    description="Composing asset operations into atomic groups, common params fields, and fees"
+  />
+  <LinkCard
+    title="Asset Metadata"
+    href="https://dev.algorand.co/concepts/assets/asset-metadata/"
+    description="Conventions and ARC standards for attaching metadata to an asset"
+  />
+</CardGrid>

--- a/examples/concepts/assets.algo.ts
+++ b/examples/concepts/assets.algo.ts
@@ -32,11 +32,20 @@ async function main() {
 
   // An account must opt in before it can hold an asset.
   // example: OPT_IN_ASSET
-  await algorand.send.assetOptIn({ sender: holder.addr, assetId, signer: holder.signer })
+  await algorand.send.assetOptIn({
+    sender: holder.addr,
+    assetId,
+    signer: holder.signer,
+  })
   // example: OPT_IN_ASSET
 
   // example: TRANSFER_ASSET
-  await algorand.send.assetTransfer({ sender: creator.addr, receiver: holder.addr, assetId, amount: 100n })
+  await algorand.send.assetTransfer({
+    sender: creator.addr,
+    receiver: holder.addr,
+    assetId,
+    amount: 100n,
+  })
   // example: TRANSFER_ASSET
 
   // Every control address must be specified explicitly on the config params;
@@ -53,7 +62,12 @@ async function main() {
   // example: RECONFIGURE_ASSET
 
   // example: FREEZE_ASSET
-  await algorand.send.assetFreeze({ sender: creator.addr, assetId, account: holder.addr, frozen: true })
+  await algorand.send.assetFreeze({
+    sender: creator.addr, // the freeze authority
+    assetId,
+    account: holder.addr,
+    frozen: true,
+  })
   // example: FREEZE_ASSET
 
   // Unfreeze so the account can participate in the remaining transactions.
@@ -72,17 +86,19 @@ async function main() {
   // example: CLAWBACK_ASSET
 
   // Two throwaway assets to demonstrate the bulk helpers.
-  const asset1Id = (await algorand.send.assetCreate({ sender: creator.addr, total: 1000n, decimals: 0, unitName: 'B1' }))
-    .assetId
-  const asset2Id = (await algorand.send.assetCreate({ sender: creator.addr, total: 1000n, decimals: 0, unitName: 'B2' }))
-    .assetId
+  const asset1Id = (await algorand.send.assetCreate({ sender: creator.addr, total: 1000n, decimals: 0, unitName: 'B1' })).assetId
+  const asset2Id = (await algorand.send.assetCreate({ sender: creator.addr, total: 1000n, decimals: 0, unitName: 'B2' })).assetId
 
   // example: BULK_OPT_IN_ASSET
-  await algorand.asset.bulkOptIn(holder.addr, [asset1Id, asset2Id], { signer: holder.signer })
+  await algorand.asset.bulkOptIn(holder.addr, [asset1Id, asset2Id], {
+    signer: holder.signer,
+  })
   // example: BULK_OPT_IN_ASSET
 
   // example: BULK_OPT_OUT_ASSET
-  await algorand.asset.bulkOptOut(holder.addr, [asset1Id, asset2Id], { signer: holder.signer })
+  await algorand.asset.bulkOptOut(holder.addr, [asset1Id, asset2Id], {
+    signer: holder.signer,
+  })
   // example: BULK_OPT_OUT_ASSET
 
   // Opt-out of a single asset (zero balance after the clawback above).
@@ -91,7 +107,7 @@ async function main() {
     sender: holder.addr,
     assetId,
     creator: creator.addr,
-    ensureZeroBalance: false,
+    ensureZeroBalance: true,
     signer: holder.signer,
   })
   // example: OPT_OUT_ASSET


### PR DESCRIPTION
## Proposed Changes

- Rewrites the legacy Assets page as the TypeScript twin of the `utils-py` Assets concept page
- Wires all 11 sections to `examples/concepts/assets.algo.ts` via `RemoteCode`
- Fixes the example's opt-out snippet to show `ensureZeroBalance: true`, matching the page's safety guidance