### PR TITLE
fix: skip suggested params cache on algod devmode

### DIFF
--- a/src/types/algorand-client.suggested-params.spec.ts
+++ b/src/types/algorand-client.suggested-params.spec.ts
@@ -1,0 +1,58 @@
+import algosdk from 'algosdk'
+import { describe, expect, test } from 'vitest'
+import { AlgorandClient } from './algorand-client'
+
+const suggestedParams = (firstValid: bigint): algosdk.SuggestedParams => ({
+  fee: 1000n,
+  firstValid,
+  lastValid: firstValid + 1000n,
+  genesisHash: new Uint8Array(32),
+  genesisID: 'sandnet-v1',
+  minFee: 1000n,
+  flatFee: true,
+})
+
+const mockAlgod = (options: { devmode: boolean }) => {
+  let firstValid = 1n
+  const algod = {
+    getTransactionParams: () => ({
+      do: async () => suggestedParams(firstValid++),
+    }),
+    genesis: () => ({
+      do: async () => JSON.stringify({ devmode: options.devmode }),
+    }),
+  }
+  return algod as unknown as algosdk.Algodv2
+}
+
+describe('AlgorandClient suggested params cache', () => {
+  test('does not cache suggested params when algod genesis reports devmode', async () => {
+    const algorand = AlgorandClient.fromClients({ algod: mockAlgod({ devmode: true }) })
+
+    const first = await algorand.getSuggestedParams()
+    const second = await algorand.getSuggestedParams()
+
+    expect(first.firstValid).toBe(1n)
+    expect(second.firstValid).toBe(2n)
+  })
+
+  test('caches suggested params when algod is not in devmode', async () => {
+    const algorand = AlgorandClient.fromClients({ algod: mockAlgod({ devmode: false }) })
+
+    const first = await algorand.getSuggestedParams()
+    const second = await algorand.getSuggestedParams()
+
+    expect(first.firstValid).toBe(1n)
+    expect(second.firstValid).toBe(1n)
+  })
+
+  test('keeps an explicit cache timeout even on a devmode network', async () => {
+    const algorand = AlgorandClient.fromClients({ algod: mockAlgod({ devmode: true }) }).setSuggestedParamsCacheTimeout(10_000)
+
+    const first = await algorand.getSuggestedParams()
+    const second = await algorand.getSuggestedParams()
+
+    expect(first.firstValid).toBe(1n)
+    expect(second.firstValid).toBe(1n)
+  })
+})

--- a/src/types/algorand-client.ts
+++ b/src/types/algorand-client.ts
@@ -27,6 +27,8 @@ export class AlgorandClient {
   private _cachedSuggestedParams?: algosdk.SuggestedParams
   private _cachedSuggestedParamsExpiry?: Date
   private _cachedSuggestedParamsTimeout: number = 3_000 // three seconds
+  private _cachedSuggestedParamsTimeoutExplicit = false
+  private _devModeSuggestedParamsChecked = false
 
   private _defaultValidityWindow: bigint | undefined = undefined
 
@@ -139,6 +141,7 @@ export class AlgorandClient {
    */
   public setSuggestedParamsCacheTimeout(timeout: number) {
     this._cachedSuggestedParamsTimeout = timeout
+    this._cachedSuggestedParamsTimeoutExplicit = true
     return this
   }
 
@@ -156,10 +159,29 @@ export class AlgorandClient {
     }
 
     this._cachedSuggestedParams = await this._clientManager.algod.getTransactionParams().do()
-    this._cachedSuggestedParamsExpiry = new Date(new Date().getTime() + this._cachedSuggestedParamsTimeout)
+
+    if (!this._devModeSuggestedParamsChecked) {
+      this._devModeSuggestedParamsChecked = true
+      if (!this._cachedSuggestedParamsTimeoutExplicit && (await this.isAlgodDevMode())) {
+        this._cachedSuggestedParamsTimeout = 0
+      }
+    }
+
+    this._cachedSuggestedParamsExpiry =
+      this._cachedSuggestedParamsTimeout <= 0 ? new Date(0) : new Date(new Date().getTime() + this._cachedSuggestedParamsTimeout)
 
     return {
       ...this._cachedSuggestedParams,
+    }
+  }
+
+  private async isAlgodDevMode(): Promise<boolean> {
+    try {
+      const raw = await this._clientManager.algod.genesis().do()
+      const genesis = (typeof raw === 'string' ? JSON.parse(raw) : raw) as { devmode?: boolean }
+      return genesis.devmode === true
+    } catch {
+      return false
     }
   }
 


### PR DESCRIPTION
## Proposed Changes

- On the first `getSuggestedParams()` call, read algod `genesis.devmode`.
- If the node is in developer mode and the caller has not set an explicit cache timeout, stop caching suggested params so `firstValid`/`lastValid` keep up with per-transaction blocks.
- An explicit `setSuggestedParamsCacheTimeout(...)` still wins.

Closes #273.

## Validation

- `npx vitest run src/types/algorand-client.suggested-params.spec.ts --coverage=false` (3 passing, no LocalNet)

Detection uses the same `algod.genesis()` JSON the repo already parses in `kmd-account-manager.ts`.