### PR TITLE
fix: encode ARC56 structs in ABI field order, not JS key order

### DIFF
--- a/src/types/app-arc56.spec.ts
+++ b/src/types/app-arc56.spec.ts
@@ -1,0 +1,57 @@
+import algosdk from 'algosdk'
+import { describe, expect, test } from 'vitest'
+import { getABIEncodedValue, getABITupleFromABIStruct, getStructFieldsForAbiType } from './app-arc56'
+
+/** Mirrors algokit-utils-ts#574: ARC-56 Message { suite: byte[6], encapsulatedKey: byte[], ciphertext: byte[] } */
+const messageStructs = {
+  Message: [
+    { name: 'suite', type: 'byte[6]' },
+    { name: 'encapsulatedKey', type: 'byte[]' },
+    { name: 'ciphertext', type: 'byte[]' },
+  ],
+}
+
+const suite = new Uint8Array([1, 2, 3, 4, 5, 6])
+const encapsulatedKey = new Uint8Array(32).fill(9)
+const ciphertext = new Uint8Array(28).fill(7)
+
+describe('ARC56 struct ABI order', () => {
+  test('getABITupleFromABIStruct follows struct field order, not object insertion order', () => {
+    const shuffled = { ciphertext, suite, encapsulatedKey }
+    const tuple = getABITupleFromABIStruct(shuffled, messageStructs.Message, messageStructs)
+
+    expect(tuple).toEqual([suite, encapsulatedKey, ciphertext])
+  })
+
+  test('getABIEncodedValue is stable when encoding a named struct with shuffled keys', () => {
+    const inOrder = getABIEncodedValue({ suite, encapsulatedKey, ciphertext }, 'Message', messageStructs)
+    const shuffled = getABIEncodedValue({ ciphertext, suite, encapsulatedKey }, 'Message', messageStructs)
+
+    expect(shuffled).toEqual(inOrder)
+  })
+
+  test('getABIEncodedValue is stable when the type is the ABI tuple string (not the struct name)', () => {
+    const tupleType = '(byte[6],byte[],byte[])'
+    const inOrder = getABIEncodedValue({ suite, encapsulatedKey, ciphertext }, tupleType, messageStructs)
+    const shuffled = getABIEncodedValue({ ciphertext, suite, encapsulatedKey }, tupleType, messageStructs)
+
+    expect(shuffled).toEqual(inOrder)
+    expect(getStructFieldsForAbiType(tupleType, messageStructs)).toEqual(messageStructs.Message)
+  })
+
+  test('algosdk cannot encode a POJO as a tuple; Object.values insertion order hits the static-array length error', () => {
+    const tupleType = algosdk.ABIType.from('(byte[6],byte[],byte[])')
+    const shuffled = { ciphertext, suite, encapsulatedKey }
+
+    expect(() => tupleType.encode(shuffled as unknown as algosdk.ABIValue[])).toThrow(/Cannot encode value/)
+    expect(() => tupleType.encode(Object.values(shuffled) as algosdk.ABIValue[])).toThrow(/Expected 6, got 28/)
+  })
+
+  test('getABIEncodedValue returns the encoded bytes when the value is already a tuple array', () => {
+    const encoded = getABIEncodedValue([suite, encapsulatedKey, ciphertext], 'Message', messageStructs)
+    const fromStruct = getABIEncodedValue({ suite, encapsulatedKey, ciphertext }, 'Message', messageStructs)
+
+    expect(encoded).toEqual(fromStruct)
+    expect(encoded.byteLength).toBeGreaterThan(0)
+  })
+})

--- a/src/types/app-arc56.ts
+++ b/src/types/app-arc56.ts
@@ -100,7 +100,42 @@ export function getABIStructFromABITuple<TReturn extends ABIStruct = Record<stri
 }
 
 /**
- * Converts an ARC-56 struct as an ABI tuple.
+ * True when `value` is a named ARC-56 struct object (not a tuple array, bytes, address, or transaction).
+ */
+export function isPlainAbiStructObject(value: unknown): value is ABIStruct {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  if (value instanceof Uint8Array) return false
+  if (typeof algosdk.Address === 'function' && value instanceof algosdk.Address) return false
+  if (typeof algosdk.Transaction === 'function' && value instanceof algosdk.Transaction) return false
+  if ('txn' in value && 'signer' in value) return false
+  if ('then' in value && typeof (value as { then?: unknown }).then === 'function') return false
+  return true
+}
+
+/**
+ * Resolves ARC-56 struct fields for an ABI type string or struct name.
+ * Matches by struct name first, then by ABI tuple type so POJO args still encode in ABI order
+ * when callers pass the tuple type (e.g. `(byte[6],byte[],byte[])`) instead of the struct name.
+ */
+export function getStructFieldsForAbiType(
+  type: string | { toString(): string },
+  structs: Record<string, StructField[]>,
+): StructField[] | undefined {
+  const typeStr = typeof type === 'string' ? type : type.toString()
+  if (structs[typeStr]) return structs[typeStr]
+  let want: string
+  try {
+    want = algosdk.ABIType.from(typeStr).toString()
+  } catch {
+    return undefined
+  }
+  return Object.values(structs).find((fields) => getABITupleTypeFromABIStructDefinition(fields, structs).toString() === want)
+}
+
+/**
+ * Converts a named ARC-56 struct object to an ABI tuple in struct-definition order.
+ *
+ * JavaScript object insertion order must not affect encoding: ABI tuples are positional.
  * @param struct The struct to convert
  * @param structFields The struct fields from an ARC-56 app spec
  * @returns The struct as a decoded ABI tuple
@@ -112,10 +147,29 @@ export function getABITupleFromABIStruct(
 ): algosdk.ABIValue[] {
   return structFields.map(({ name: key, type }) => {
     const value = struct[key]
+    if (value === undefined) {
+      throw new Error(`Missing struct field '${key}' when encoding ARC-56 struct`)
+    }
     return typeof type === 'string' && !structs[type]
       ? (value as algosdk.ABIValue)
       : getABITupleFromABIStruct(value as ABIStruct, typeof type === 'string' ? structs[type] : type, structs)
   })
+}
+
+/**
+ * If `value` is a named struct object, convert it to an ABI tuple using ARC-56 field order.
+ * Otherwise return `value` unchanged.
+ */
+export function coerceAbiStructValueToTuple(
+  value: unknown,
+  type: string | { toString(): string },
+  structs: Record<string, StructField[]>,
+  structName?: string,
+): unknown {
+  if (!isPlainAbiStructObject(value)) return value
+  const fields = (structName && structs[structName]) || getStructFieldsForAbiType(type, structs)
+  if (!fields) return value
+  return getABITupleFromABIStruct(value, fields, structs)
 }
 
 /** Decoded ARC-56 struct as a struct rather than a tuple. */
@@ -170,10 +224,15 @@ export function getABIEncodedValue(
   }
   if (structs[type]) {
     const tupleType = getABITupleTypeFromABIStructDefinition(structs[type], structs)
-    if (Array.isArray(value)) {
-      tupleType.encode(value as algosdk.ABIValue[])
-    } else {
-      return tupleType.encode(getABITupleFromABIStruct(value as ABIStruct, structs[type], structs))
+    const tupleValue = Array.isArray(value)
+      ? (value as algosdk.ABIValue[])
+      : getABITupleFromABIStruct(value as ABIStruct, structs[type], structs)
+    return tupleType.encode(tupleValue)
+  }
+  if (isPlainAbiStructObject(value)) {
+    const fields = getStructFieldsForAbiType(type, structs)
+    if (fields) {
+      return getABITupleTypeFromABIStructDefinition(fields, structs).encode(getABITupleFromABIStruct(value, fields, structs))
     }
   }
   return algosdk.ABIType.from(type).encode(value as algosdk.ABIValue)

--- a/src/types/app-client.ts
+++ b/src/types/app-client.ts
@@ -46,6 +46,7 @@ import {
   ABIStruct,
   Arc56Contract,
   Arc56Method,
+  coerceAbiStructValueToTuple,
   getABIDecodedValue,
   getABIEncodedValue,
   getABITupleFromABIStruct,
@@ -1120,10 +1121,8 @@ export class AppClient {
           throw new Error(`Unexpected arg at position ${i}. ${m.name} only expects ${m.args.length} args`)
         }
         if (a !== undefined) {
-          // If a struct then convert to tuple for the underlying call
-          return arg.struct && typeof a === 'object' && !Array.isArray(a)
-            ? getABITupleFromABIStruct(a as ABIStruct, this._appSpec.structs[arg.struct], this._appSpec.structs)
-            : (a as ABIValue | AppMethodCallTransactionArgument)
+          // Named struct objects must be encoded in ARC-56 field order, not JS insertion order
+          return coerceAbiStructValueToTuple(a, arg.type, this._appSpec.structs, arg.struct) as ABIValue | AppMethodCallTransactionArgument
         }
         const defaultValue = arg.defaultValue
         if (defaultValue) {

--- a/src/types/app-factory.ts
+++ b/src/types/app-factory.ts
@@ -13,8 +13,8 @@ import {
   ABIStruct,
   Arc56Contract,
   Arc56Method,
+  coerceAbiStructValueToTuple,
   getABIDecodedValue,
-  getABITupleFromABIStruct,
   getArc56Method,
   getArc56ReturnValue,
 } from './app-arc56'
@@ -669,10 +669,8 @@ export class AppFactory {
     return args?.map((a, i) => {
       const arg = m.args[i]
       if (a !== undefined) {
-        // If a struct then convert to tuple for the underlying call
-        return arg.struct && typeof a === 'object' && !Array.isArray(a)
-          ? getABITupleFromABIStruct(a as ABIStruct, this._appSpec.structs[arg.struct], this._appSpec.structs)
-          : (a as ABIValue | AppMethodCallTransactionArgument)
+        // Named struct objects must be encoded in ARC-56 field order, not JS insertion order
+        return coerceAbiStructValueToTuple(a, arg.type, this._appSpec.structs, arg.struct) as ABIValue | AppMethodCallTransactionArgument
       }
       const defaultValue = arg.defaultValue
       if (defaultValue) {


### PR DESCRIPTION
## Summary
ARC-56 structs are ABI tuples. Encoding a JS object with keys out of definition order (or passing the ABI tuple type string instead of the struct name) could encode fields positionally wrong — e.g. `byte[6]` receiving a 28-byte ciphertext (`Expected 6, got 28`).

- Convert named struct objects to tuples using ARC-56 field order in `getABIEncodedValue`, AppClient, and AppFactory
- Resolve struct metadata from the ABI tuple type when the caller does not pass the struct name
- Return encoded bytes when the value is already a tuple array (previously the encode result was dropped)

## Test plan
- [x] `npx vitest run src/types/app-arc56.spec.ts` — 5 passing
- [x] `npx tsc --project tsconfig.typecheck.json --noEmit`
- [x] `npx eslint` on the touched files

Fixes #574