### PR TITLE
fix: error on unresolved TMPL_ vars before TEAL compile

### DIFF
--- a/src/app-deploy.spec.ts
+++ b/src/app-deploy.spec.ts
@@ -1,4 +1,4 @@
-import { getApplicationAddress } from 'algosdk'
+import algosdk, { getApplicationAddress } from 'algosdk'
 import invariant from 'tiny-invariant'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { getTestingAppCreateParams, getTestingAppDeployParams } from '../tests/example-contracts/testing-app/contract'
@@ -655,6 +655,38 @@ pushbytes "b64 //8="
   const result = AppManager.stripTealComments(tealCode)
 
   expect(result).toBe(tealCodeResult)
+})
+
+test('compileTeal throws before calling algod when TMPL vars remain', async () => {
+  const algod = {
+    compile: () => {
+      throw new Error('algod should not be called')
+    },
+  } as unknown as algosdk.Algodv2
+  const appManager = new AppManager(algod)
+  await expect(appManager.compileTeal('int TMPL_NFD_REGISTRY_APP_ID\nreturn')).rejects.toThrow(
+    /Undefined TEAL template variable\(s\): TMPL_NFD_REGISTRY_APP_ID/,
+  )
+})
+
+test('Reports leftover TMPL variables instead of sending them to algod', () => {
+  const teal = `
+  int TMPL_NFD_REGISTRY_APP_ID // should still be reported
+  int TMPL_OTHER
+  byte "TMPL_QUOTED"
+  int NOTTMPL_X
+  return
+  `
+  expect(AppManager.findUnresolvedTealTemplateVars(teal)).toEqual(['TMPL_NFD_REGISTRY_APP_ID', 'TMPL_OTHER'])
+})
+
+test('Does not report TMPL tokens that were substituted', () => {
+  const teal = `
+  int TMPL_SOME_VALUE
+  return
+  `
+  const substituted = AppManager.replaceTealTemplateParams(teal, { SOME_VALUE: 123 })
+  expect(AppManager.findUnresolvedTealTemplateVars(substituted)).toEqual([])
 })
 
 test('Can substitute template variable with multiple underscores', async () => {

--- a/src/types/app-manager.ts
+++ b/src/types/app-manager.ts
@@ -163,6 +163,14 @@ export class AppManager {
    * ```
    */
   async compileTeal(tealCode: string): Promise<CompiledTeal> {
+    const unresolved = AppManager.findUnresolvedTealTemplateVars(tealCode)
+    if (unresolved.length > 0) {
+      throw new Error(
+        `Undefined TEAL template variable(s): ${unresolved.join(', ')}. ` +
+          `Pass them via compileTealTemplate templateParams (or replaceTealTemplateParams) before compiling.`,
+      )
+    }
+
     if (this._compilationResults[tealCode]) {
       return this._compilationResults[tealCode]
     }
@@ -522,6 +530,33 @@ export class AppManager {
    * const tealCode = AppManager.replaceTealTemplateParams(tealTemplate, { TMPL_APP_ID: 12345n });
    * ```
    */
+  /**
+   * Returns leftover `TMPL_*` tokens in TEAL (ignoring comments and quoted strings).
+   * Used to fail compilation with a clear error instead of algod's ParseUint message.
+   */
+  static findUnresolvedTealTemplateVars(tealCode: string): string[] {
+    const found = new Set<string>()
+    for (const line of tealCode.split('\n')) {
+      const commentIndex = findUnquotedString(line, '//')
+      const code = commentIndex === undefined ? line : line.slice(0, commentIndex)
+      let index = 0
+      while (index < code.length) {
+        const tokenIndex = findUnquotedString(code, 'TMPL_', index)
+        if (tokenIndex === undefined) {
+          break
+        }
+        const match = code.slice(tokenIndex).match(/^TMPL_[A-Z0-9_]+/)
+        if (match && (tokenIndex === 0 || !/[A-Za-z0-9_]/.test(code[tokenIndex - 1] ?? ''))) {
+          found.add(match[0])
+          index = tokenIndex + match[0].length
+        } else {
+          index = tokenIndex + 5
+        }
+      }
+    }
+    return [...found]
+  }
+
   static replaceTealTemplateParams(tealTemplateCode: string, templateParams?: TealTemplateParams) {
     if (templateParams !== undefined) {
       for (const key in templateParams) {


### PR DESCRIPTION
## Proposed Changes

- Scan TEAL for leftover `TMPL_*` tokens (skipping comments and quoted strings) before calling algod compile.
- Throw a clear error listing the undefined variables instead of algod's \`strconv.ParseUint: parsing \"TMPL_…\": invalid syntax\`.

Closes #424.

## Validation

- \`npx vitest run src/app-deploy.spec.ts -t 'leftover TMPL|tokens that were substituted|compileTeal throws'\` — 3 passing, no LocalNet
- \`npx tsc --project tsconfig.typecheck.json --noEmit\`
- \`npx eslint\` on the touched files