### PR TITLE
feat: support resizing an app as part of an update for AVM 13

### DIFF
--- a/docs/src/content/docs/capabilities/app-client.md
+++ b/docs/src/content/docs/capabilities/app-client.md
@@ -208,6 +208,8 @@ If you want to construct a custom deploy call, use the underlying [`algorand.app
 
 Deploy method aside, the ability to make update and delete calls happens after there is an instance of an app so are done via `AppClient`. The semantics of this are no different than [other calls](#calling-the-app), with the caveat that the update call is a bit different to the others since the code will be compiled when constructing the update params (making it an async method) and the update calls thus optionally takes compilation parameters (`deployTimeParams`, `updatable` and `deletable`) for [deploy-time parameter replacements and deploy-time immutability and permanence control](/algokit-utils-ts/capabilities/app-deploy/#compilation-and-template-substitution).
 
+Update calls also optionally take the `schema` and `extraProgramPages` parameters to [resize the app](/algokit-utils-ts/capabilities/app/#resizing-an-app) as part of the update.
+
 ## Calling the app
 
 You can construct a params object, transaction(s) and sign and send a transaction to call the app that a given `AppClient` instance is pointing to.

--- a/docs/src/content/docs/capabilities/app.md
+++ b/docs/src/content/docs/capabilities/app.md
@@ -143,6 +143,10 @@ The base type for specifying an app update transaction is `AppUpdateParams` (ext
 - `onComplete?: algosdk.OnApplicationComplete.UpdateApplicationOC` - On Complete can either be omitted or set to update
 - `approvalProgram: Uint8Array | string` - The program to execute for all OnCompletes other than ClearState as raw teal that will be compiled (string) or compiled teal (encoded as a byte array (Uint8Array)).
 - `clearStateProgram: Uint8Array | string` - The program to execute for ClearState OnComplete as raw teal that will be compiled (string) or compiled teal (encoded as a byte array (Uint8Array)).
+- `schema?` - The global state schema to resize the app to. It is an object with:
+  - `globalInts: number` - The number of integers saved in global state.
+  - `globalByteSlices: number` - The number of byte slices saved in global state.
+- `extraProgramPages?: number` - The number of extra pages to allocate for the programs.
 
 If you pass in `approvalProgram` or `clearStateProgram` as a string then it will automatically be compiled using Algod and the compilation result will be available via `algorand.app.getCompilationResult` (including the source map). To skip this behaviour you can pass in the compiled TEAL as `Uint8Array`.
 
@@ -191,6 +195,35 @@ await algorand.send.appUpdateMethodCall({
   clearStateProgram: 'TEALCODE',
   method: method,
   args: ["arg1_value"]
+})
+```
+
+#### Resizing an app
+
+`schema` and `extraProgramPages` require AVM 13 (consensus v42) or later; before that an app's size is fixed when it's created. Both can only be increased: the global state schema can't be reduced below the state the app has already stored, the app can't be given fewer pages than its programs need, and the local state schema stays immutable. Growing an app also costs minimum balance, since the account sending the update takes on the app's size sponsor role and needs to hold the minimum balance for its extra program pages and global state slots.
+
+If neither property is specified the app keeps its current size. The AVM applies both properties together, so if you specify only one of them then the other is automatically resolved to the app's current on-chain value (which costs an extra algod call to look the app up).
+
+```typescript
+// Give the app 3 more global ints, keeping its current extra program pages
+await algorand.send.appUpdate({
+  sender: 'SENDERADDRESS',
+  appId: 12345n,
+  approvalProgram: 'TEALCODE',
+  clearStateProgram: 'TEALCODE',
+  schema: {
+    globalInts: 5,
+    globalByteSlices: 2,
+  },
+})
+
+// Give the app 4 extra program pages, keeping its current global state schema
+await algorand.send.appUpdate({
+  sender: 'SENDERADDRESS',
+  appId: 12345n,
+  approvalProgram: 'TEALCODE',
+  clearStateProgram: 'TEALCODE',
+  extraProgramPages: 4,
 })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "node": ">=22.0"
       },
       "peerDependencies": {
-        "algosdk": "^3.5.2"
+        "algosdk": "^3.7.0"
       }
     },
     "node_modules/@actions/core": {
@@ -2959,9 +2959,9 @@
       }
     },
     "node_modules/algosdk": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-3.6.0.tgz",
-      "integrity": "sha512-pdM0neCgR3DasvpSPfgQKc5/hlhkSYmXjcUChePLGegA0kqA0AoLmcfMDyeREcsvHcu7rrv3Wa+RZnGa5kINwQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-3.7.0.tgz",
+      "integrity": "sha512-6mr5w+A+A87/rAd4Y5hSmKSfvLkOKeik81w8Tte9ZxSqnwqUuWUioQsJail3ZyCbJtEctJXJTxe7Sx50/lQi3g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "buffer": "^6.0.3"
   },
   "peerDependencies": {
-    "algosdk": "^3.5.2"
+    "algosdk": "^3.7.0"
   },
   "devDependencies": {
     "@algorandfoundation/tealscript": "^0.106.3",

--- a/src/app.spec.ts
+++ b/src/app.spec.ts
@@ -27,6 +27,63 @@ describe('app', () => {
     expect(BigInt(app.confirmation?.applicationIndex ?? 0)).toBe(app.appId)
   })
 
+  /** Creates an updatable instance of the testing app and returns it along with the programs and schema it was created with. */
+  const createUpdatableApp = async () => {
+    const { algorand, testAccount } = localnet.context
+    const contract = await getTestingAppContract()
+    const programs = {
+      approvalProgram: contract.approvalProgram.replace('TMPL_UPDATABLE', '1').replace('TMPL_DELETABLE', '0').replace('TMPL_VALUE', '1'),
+      clearStateProgram: contract.clearStateProgram,
+    }
+
+    const app = await algorand.send.appCreate({ ...programs, schema: contract.stateSchema, sender: testAccount })
+
+    return { appId: app.appId, programs, schema: contract.stateSchema }
+  }
+
+  test('appUpdate expands the global state schema', async () => {
+    const { algorand, testAccount } = localnet.context
+    const { appId, programs, schema } = await createUpdatableApp()
+
+    await algorand.send.appUpdate({
+      appId,
+      ...programs,
+      schema: { globalInts: schema.globalInts + 2, globalByteSlices: schema.globalByteSlices + 1 },
+      sender: testAccount,
+    })
+
+    const updated = await algorand.app.getById(appId)
+    expect(updated.globalInts).toBe(schema.globalInts + 2)
+    expect(updated.globalByteSlices).toBe(schema.globalByteSlices + 1)
+    // The local state schema is immutable once an app is created
+    expect(updated.localInts).toBe(schema.localInts)
+    expect(updated.localByteSlices).toBe(schema.localByteSlices)
+  })
+
+  test('appUpdate adds extra program pages while keeping the existing global state schema', async () => {
+    const { algorand, testAccount } = localnet.context
+    const { appId, programs, schema } = await createUpdatableApp()
+
+    await algorand.send.appUpdate({ appId, ...programs, extraProgramPages: 1, sender: testAccount })
+
+    const updated = await algorand.app.getById(appId)
+    expect(updated.extraProgramPages).toBe(1)
+    expect(updated.globalInts).toBe(schema.globalInts)
+    expect(updated.globalByteSlices).toBe(schema.globalByteSlices)
+  })
+
+  test('appUpdate without a schema keeps the existing app size', async () => {
+    const { algorand, testAccount } = localnet.context
+    const { appId, programs, schema } = await createUpdatableApp()
+
+    await algorand.send.appUpdate({ appId, ...programs, sender: testAccount })
+
+    const updated = await algorand.app.getById(appId)
+    expect(updated.globalInts).toBe(schema.globalInts)
+    expect(updated.globalByteSlices).toBe(schema.globalByteSlices)
+    expect(updated.extraProgramPages).toBe(0)
+  })
+
   test('appCreate with rekey performs rekey', async () => {
     const { algorand, testAccount } = localnet.context
     const rekeyTo = algorand.account.random()

--- a/src/types/app-client.ts
+++ b/src/types/app-client.ts
@@ -67,6 +67,7 @@ import {
   AppMethodCallTransactionArgument,
   AppUpdateMethodCall,
   AppUpdateParams,
+  AppUpdateSchema,
   CommonAppCallParams,
   PaymentParams,
 } from './composer'
@@ -1192,7 +1193,7 @@ export class AppClient {
   private getBareParamsMethods() {
     return {
       /** Return params for an update call, including deploy-time TEAL template replacements and compilation if provided */
-      update: async (params?: AppClientBareCallParams & AppClientCompilationParams) => {
+      update: async (params?: AppClientBareCallParams & AppClientCompilationParams & AppUpdateSchema) => {
         return this.getBareParams(
           {
             ...params,
@@ -1227,7 +1228,7 @@ export class AppClient {
   private getBareCreateTransactionMethods() {
     return {
       /** Returns a transaction for an update call, including deploy-time TEAL template replacements and compilation if provided */
-      update: async (params?: AppClientBareCallParams & AppClientCompilationParams) => {
+      update: async (params?: AppClientBareCallParams & AppClientCompilationParams & AppUpdateSchema) => {
         return this._algorand.createTransaction.appUpdate(await this.params.bare.update(params))
       },
       /** Returns a transaction for an opt-in call */
@@ -1256,7 +1257,7 @@ export class AppClient {
   private getBareSendMethods() {
     return {
       /** Signs and sends an update call, including deploy-time TEAL template replacements and compilation if provided */
-      update: async (params?: AppClientBareCallParams & AppClientCompilationParams & SendParams) => {
+      update: async (params?: AppClientBareCallParams & AppClientCompilationParams & AppUpdateSchema & SendParams) => {
         const compiled = await this.compile(params)
         return {
           ...(await this._algorand.send.appUpdate(await this.params.bare.update(params))),
@@ -1306,7 +1307,7 @@ export class AppClient {
        * @param params The parameters for the update ABI method call
        * @returns The parameters which can be used to create an update ABI method call
        */
-      update: async (params: AppClientMethodCallParams & AppClientCompilationParams) => {
+      update: async (params: AppClientMethodCallParams & AppClientCompilationParams & AppUpdateSchema) => {
         return (await this.getABIParams(
           {
             ...params,
@@ -1362,7 +1363,7 @@ export class AppClient {
        * @param params The parameters for the update ABI method call
        * @returns The result of sending the update ABI method call
        */
-      update: async (params: AppClientMethodCallParams & AppClientCompilationParams & SendParams) => {
+      update: async (params: AppClientMethodCallParams & AppClientCompilationParams & AppUpdateSchema & SendParams) => {
         const compiled = await this.compile(params)
         return {
           ...(await this.processMethodCallReturn(
@@ -1484,7 +1485,7 @@ export class AppClient {
        * @param params The parameters for the update ABI method call
        * @returns The transactions which can be used to create an update ABI method call
        */
-      update: async (params: AppClientMethodCallParams & AppClientCompilationParams) => {
+      update: async (params: AppClientMethodCallParams & AppClientCompilationParams & AppUpdateSchema) => {
         return this._algorand.createTransaction.appUpdateMethodCall(await this.params.update(params))
       },
       /**

--- a/src/types/app-factory-and-client.spec.ts
+++ b/src/types/app-factory-and-client.spec.ts
@@ -163,6 +163,30 @@ describe('ARC32: app-factory-and-app-client', () => {
     expect(app.updatedRound).toBe(app.confirmation.confirmedRound ?? 0n)
   })
 
+  test('Deploy app - update expands the global state schema', async () => {
+    const { result: createdApp } = await factory.deploy({
+      deployTimeParams: {
+        VALUE: 1,
+      },
+      updatable: true,
+    })
+    const { result: app } = await factory.deploy({
+      deployTimeParams: {
+        VALUE: 2,
+      },
+      onUpdate: 'update',
+      updateParams: {
+        schema: { globalInts: 5, globalByteSlices: 3 },
+      },
+    })
+
+    invariant(app.operationPerformed === 'update')
+    expect(app.appId).toBe(createdApp.appId)
+    const appInfo = await localnet.algorand.app.getById(app.appId)
+    expect(appInfo.globalInts).toBe(5)
+    expect(appInfo.globalByteSlices).toBe(3)
+  })
+
   test('Deploy app - update (abi)', async () => {
     const { result: createdApp } = await factory.deploy({
       deployTimeParams: {
@@ -416,6 +440,29 @@ describe('ARC32: app-factory-and-app-client', () => {
     invariant(call.return)
     expect(call.return).toBe('string_io')
     expect(call.compiledApproval).toBeTruthy()
+  })
+
+  test('Update app with abi and expand the global state schema', async () => {
+    const deployTimeParams = {
+      UPDATABLE: 1,
+      DELETABLE: 0,
+      VALUE: 1,
+    }
+    const { appClient } = await factory.send.bare.create({
+      deployTimeParams,
+    })
+
+    const call = await appClient.send.update({
+      method: 'update_abi',
+      args: ['string_io'],
+      deployTimeParams,
+      schema: { globalInts: 5, globalByteSlices: 3 },
+    })
+
+    expect(call.return).toBe('string_io')
+    const app = await localnet.algorand.app.getById(appClient.appId)
+    expect(app.globalInts).toBe(5)
+    expect(app.globalByteSlices).toBe(3)
   })
 
   test('Delete app with abi', async () => {

--- a/src/types/app-factory.ts
+++ b/src/types/app-factory.ts
@@ -35,7 +35,14 @@ import {
   DeployAppUpdateParams,
 } from './app-deployer'
 import { AppSpec } from './app-spec'
-import { AppCreateMethodCall, AppCreateParams, AppMethodCall, AppMethodCallTransactionArgument, CommonAppCallParams } from './composer'
+import {
+  AppCreateMethodCall,
+  AppCreateParams,
+  AppMethodCall,
+  AppMethodCallTransactionArgument,
+  AppUpdateSchema,
+  CommonAppCallParams,
+} from './composer'
 import { Expand } from './expand'
 import { SendParams } from './transaction'
 import SourceMap = algosdk.ProgramSourceMap
@@ -144,7 +151,7 @@ export type AppFactoryDeployParams = Expand<
       | Expand<AppClientMethodCallParams & CreateOnComplete & CreateSchema>
       | Expand<AppClientBareCallParams & CreateOnComplete & CreateSchema>
     /** Update transaction parameters to use if a create needs to be issued as part of deployment */
-    updateParams?: AppClientMethodCallParams | AppClientBareCallParams
+    updateParams?: Expand<AppClientMethodCallParams & AppUpdateSchema> | Expand<AppClientBareCallParams & AppUpdateSchema>
     /** Delete transaction parameters to use if a create needs to be issued as part of deployment */
     deleteParams?: AppClientMethodCallParams | AppClientBareCallParams
     /**
@@ -556,7 +563,7 @@ export class AppFactory {
         ) satisfies AppCreateMethodCall
       },
       /** Return params for a deployment update ABI call */
-      deployUpdate: (params: AppClientMethodCallParams) => {
+      deployUpdate: (params: AppClientMethodCallParams & AppUpdateSchema) => {
         return this.getABIParams(params, OnApplicationComplete.UpdateApplicationOC) satisfies DeployAppUpdateMethodCall
       },
       /** Return params for a deployment delete ABI call */
@@ -582,7 +589,7 @@ export class AppFactory {
           ) satisfies AppCreateParams
         },
         /** Return params for a deployment update bare call */
-        deployUpdate: (params?: AppClientBareCallParams) => {
+        deployUpdate: (params?: AppClientBareCallParams & AppUpdateSchema) => {
           return this.getBareParams(params, OnApplicationComplete.UpdateApplicationOC) satisfies DeployAppUpdateParams
         },
         /** Return params for a deployment delete bare call */

--- a/src/types/composer.ts
+++ b/src/types/composer.ts
@@ -391,15 +391,39 @@ export type AppCreateParams = Expand<
   }
 >
 
+/**
+ * The size properties of an app that an app update transaction can change.
+ *
+ * Both properties require AVM 13 (consensus v42) or later; before that an app's size is fixed at creation.
+ *
+ * The AVM applies the global state schema and the extra program pages of an update together, so if only one of
+ * these properties is specified the other one is automatically resolved to the app's current on-chain value.
+ * If neither is specified the app keeps its current size.
+ */
+export type AppUpdateSchema = {
+  /** The global state schema to resize the app to; the local state schema is immutable once the app is created.
+   *
+   * The schema can't be reduced below the global state the app has already stored. */
+  schema?: {
+    /** The number of integers saved in global state. */
+    globalInts: number
+    /** The number of byte slices saved in global state. */
+    globalByteSlices: number
+  }
+  /** The number of extra pages to allocate for the programs; the app can't be given fewer pages than its programs need. */
+  extraProgramPages?: number
+}
+
 /** Parameters to define an app update transaction */
 export type AppUpdateParams = Expand<
-  CommonAppCallParams & {
-    onComplete?: algosdk.OnApplicationComplete.UpdateApplicationOC
-    /** The program to execute for all OnCompletes other than ClearState as raw teal (string) or compiled teal (base 64 encoded as a byte array (Uint8Array)) */
-    approvalProgram: string | Uint8Array
-    /** The program to execute for ClearState OnComplete as raw teal (string) or compiled teal (base 64 encoded as a byte array (Uint8Array)) */
-    clearStateProgram: string | Uint8Array
-  }
+  CommonAppCallParams &
+    AppUpdateSchema & {
+      onComplete?: algosdk.OnApplicationComplete.UpdateApplicationOC
+      /** The program to execute for all OnCompletes other than ClearState as raw teal (string) or compiled teal (base 64 encoded as a byte array (Uint8Array)) */
+      approvalProgram: string | Uint8Array
+      /** The program to execute for ClearState OnComplete as raw teal (string) or compiled teal (base 64 encoded as a byte array (Uint8Array)) */
+      clearStateProgram: string | Uint8Array
+    }
 >
 
 /** Parameters to define an application call transaction. */
@@ -1637,6 +1661,9 @@ export class TransactionComposer {
           : params.clearStateProgram
         : undefined
 
+    const { schema, createSchema, extraProgramPages } = getAppSizeParams(params)
+    const appSizeChange = appId === 0 ? undefined : await this.resolveAppSizeChange(BigInt(appId), schema, extraProgramPages)
+
     const txnParams = {
       appID: appId,
       sender: params.sender,
@@ -1651,16 +1678,12 @@ export class TransactionComposer {
       clearProgram: clearStateProgram,
       extraPages:
         appId === 0
-          ? 'extraProgramPages' in params && params.extraProgramPages !== undefined
-            ? params.extraProgramPages
-            : approvalProgram
-              ? calculateExtraProgramPages(approvalProgram, clearStateProgram)
-              : 0
-          : undefined,
-      numLocalInts: appId === 0 ? ('schema' in params ? (params.schema?.localInts ?? 0) : 0) : undefined,
-      numLocalByteSlices: appId === 0 ? ('schema' in params ? (params.schema?.localByteSlices ?? 0) : 0) : undefined,
-      numGlobalInts: appId === 0 ? ('schema' in params ? (params.schema?.globalInts ?? 0) : 0) : undefined,
-      numGlobalByteSlices: appId === 0 ? ('schema' in params ? (params.schema?.globalByteSlices ?? 0) : 0) : undefined,
+          ? (extraProgramPages ?? (approvalProgram ? calculateExtraProgramPages(approvalProgram, clearStateProgram) : 0))
+          : appSizeChange?.extraPages,
+      numLocalInts: appId === 0 ? (createSchema?.localInts ?? 0) : undefined,
+      numLocalByteSlices: appId === 0 ? (createSchema?.localByteSlices ?? 0) : undefined,
+      numGlobalInts: appId === 0 ? (createSchema?.globalInts ?? 0) : appSizeChange?.numGlobalInts,
+      numGlobalByteSlices: appId === 0 ? (createSchema?.globalByteSlices ?? 0) : appSizeChange?.numGlobalByteSlices,
       method: params.method,
       signer: includeSigner
         ? params.signer
@@ -1811,6 +1834,8 @@ export class TransactionComposer {
       rejectVersion: params.rejectVersion,
     }
 
+    const { schema, createSchema, extraProgramPages } = getAppSizeParams(params)
+
     if (appId === 0n) {
       if (sdkParams.approvalProgram === undefined || sdkParams.clearProgram === undefined) {
         throw new Error('approvalProgram and clearStateProgram are required for application creation')
@@ -1818,19 +1843,39 @@ export class TransactionComposer {
 
       return this.commonTxnBuildStep(algosdk.makeApplicationCreateTxnFromObject, params, {
         ...sdkParams,
-        extraPages:
-          'extraProgramPages' in params && params.extraProgramPages !== undefined
-            ? params.extraProgramPages
-            : calculateExtraProgramPages(approvalProgram!, clearStateProgram!),
-        numLocalInts: 'schema' in params ? (params.schema?.localInts ?? 0) : 0,
-        numLocalByteSlices: 'schema' in params ? (params.schema?.localByteSlices ?? 0) : 0,
-        numGlobalInts: 'schema' in params ? (params.schema?.globalInts ?? 0) : 0,
-        numGlobalByteSlices: 'schema' in params ? (params.schema?.globalByteSlices ?? 0) : 0,
+        extraPages: extraProgramPages ?? calculateExtraProgramPages(approvalProgram!, clearStateProgram!),
+        numLocalInts: createSchema?.localInts ?? 0,
+        numLocalByteSlices: createSchema?.localByteSlices ?? 0,
+        numGlobalInts: createSchema?.globalInts ?? 0,
+        numGlobalByteSlices: createSchema?.globalByteSlices ?? 0,
         approvalProgram: approvalProgram!,
         clearProgram: clearStateProgram!,
       })
     } else {
-      return this.commonTxnBuildStep(algosdk.makeApplicationCallTxnFromObject, params, { ...sdkParams, appIndex: appId })
+      return this.commonTxnBuildStep(algosdk.makeApplicationCallTxnFromObject, params, {
+        ...sdkParams,
+        appIndex: appId,
+        ...(await this.resolveAppSizeChange(appId, schema, extraProgramPages)),
+      })
+    }
+  }
+
+  /**
+   * Resolves the size properties to set on an app update transaction, or `undefined` if no resize was requested
+   * (in which case the transaction is built without them and the app keeps its current size).
+   *
+   * The AVM applies an update's global state schema and extra program pages together, so whenever only one of them
+   * is specified the other is resolved from the app's current on-chain value rather than being left at zero.
+   */
+  private async resolveAppSizeChange(appId: bigint, schema: AppUpdateSchema['schema'], extraProgramPages: number | undefined) {
+    if (schema === undefined && extraProgramPages === undefined) return undefined
+
+    const existing = schema === undefined || extraProgramPages === undefined ? await this.appManager.getById(appId) : undefined
+
+    return {
+      numGlobalInts: schema?.globalInts ?? existing!.globalInts,
+      numGlobalByteSlices: schema?.globalByteSlices ?? existing!.globalByteSlices,
+      extraPages: extraProgramPages ?? existing!.extraProgramPages,
     }
   }
 
@@ -2189,6 +2234,23 @@ export class TransactionComposer {
     const arc2Payload = `${note.dAppName}:${note.format}${typeof note.data === 'string' ? note.data : asJson(note.data)}`
     const encoder = new TextEncoder()
     return encoder.encode(arc2Payload)
+  }
+}
+
+/**
+ * Extracts the size related parameters (state schema and extra program pages) from any app call params.
+ *
+ * `createSchema` is only populated when the params carry a create schema (i.e. one that includes the
+ * local state schema), since the local state schema can only be set when an app is created.
+ */
+function getAppSizeParams(
+  params: AppCallParams | AppCreateParams | AppUpdateParams | AppCallMethodCall | AppCreateMethodCall | AppUpdateMethodCall,
+) {
+  const schema = 'schema' in params ? params.schema : undefined
+  return {
+    schema,
+    createSchema: schema && 'localInts' in schema ? (schema as NonNullable<AppCreateParams['schema']>) : undefined,
+    extraProgramPages: 'extraProgramPages' in params ? params.extraProgramPages : undefined,
   }
 }
 


### PR DESCRIPTION
## Proposed Changes

- Add an `appSize` param to `AppUpdateParams` and thread it through the transaction composer, `algorand.createTransaction.appUpdate`/`appUpdateMethodCall`, `algorand.send.*`, `AppClient.params/createTransaction/send.update` (bare and ABI), and the `AppFactory`/`AppDeployer` update params — AVM 13 (consensus v42) makes an app's global state schema and extra program pages mutable, so growing an app no longer requires deleting and recreating it.
- `appSize` is a single optional value holding `globalInts`, `globalByteSlices` and `extraProgramPages`, because the AVM sets all three together and applies them as the app's whole new size rather than as an increase. Leaving it undefined builds the transaction exactly as before and the app keeps its current size.
- Bump the `algosdk` peer dependency to `^3.7.0`, the first version whose `AtomicTransactionComposer` permits these fields on an update call (3.6.0 and earlier reject them outright, which the ABI update path goes through).

### Notes

- The three counts are grouped rather than exposed as separate optional params so that specifying a partial size is a type error instead of a runtime rejection from the AVM (an update carrying only `extraProgramPages` asks the AVM to shrink the global schema to zero and is rejected). A both-or-nothing union of two top-level params was the alternative, but TypeScript collapses a union when it is spread into another object literal, so composing update params with `{...updateParams}` — which `AppDeployer` and most callers do — would have lost the correlation and stopped compiling.
- The local state schema stays immutable on update; the AVM rejects a non-zero local schema on an update outright, so `appSize` deliberately has no local counts.
- `AppDeployer`'s schema-break detection is unchanged: a global state schema increase in the app spec is still treated as a break and handled by `onSchemaBreak`. Teaching `deploy` to grow an existing app in place instead of replacing it is a follow-up, since it changes deployment semantics.

### Testing

- Added LocalNet tests covering a bare update that expands the global state schema, an update that adds extra program pages, an update with no `appSize` leaving the app unchanged, an ABI method call update via `AppClient` and an `AppFactory.deploy` update — all verified against the resulting on-chain app record.
- Full suite passes (405 passed, 2 skipped) against LocalNet running Algorand 5.0 / AVM 13.