### PR TITLE
docs: fix transactions concepts link on asset page

### DIFF
--- a/docs/src/content/docs/concepts/asset.mdx
+++ b/docs/src/content/docs/concepts/asset.mdx
@@ -158,7 +158,7 @@ Three asset behaviors deserve attention because their effects are difficult or i
   />
   <LinkCard
     title="Transactions"
-    href="/algokit-utils-ts/concepts/transaction/"
+    href="/algokit-utils-ts/concepts/transactions/"
     description="Composing asset operations into atomic groups, common params fields, and fees"
   />
   <LinkCard


### PR DESCRIPTION
Link audit follow-up, asset.mdx still pointed at the old singular `concepts/transaction/` slug (same rename fallout as #598)