### PR TITLE
fix(v10): resolve transaction IDs from the signed transactions

### DIFF
--- a/src/composer.spec.ts
+++ b/src/composer.spec.ts
@@ -3,10 +3,12 @@ import { Address } from '@algorandfoundation/algokit-common'
 import {
   decodeSignedTransaction,
   generateAddressWithSigners,
+  groupTransactions,
   Transaction,
   TransactionSigner,
   TransactionType,
 } from '@algorandfoundation/algokit-transact'
+import { Buffer } from 'buffer'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { algo, AlgoAmount } from './amount'
 import { algorandFixture } from './testing'
@@ -618,6 +620,103 @@ describe('TransactionComposer', () => {
       })
 
       await expect(composer.gatherSignatures()).rejects.toThrow('Transactions at indexes [0] were not signed')
+    })
+  })
+
+  describe('signers that mutate transactions', () => {
+    test('should use the mutated transaction when waiting for confirmation of a single transaction', async () => {
+      const { algorand, context } = fixture
+      const sender = context.testAccount
+      const note = new TextEncoder().encode('mutated by the wallet')
+
+      let builtTxId: string | undefined
+      const mutatingSigner: TransactionSigner = async (group, indexes) => {
+        builtTxId = group[0].txId()
+        const mutated = group.map((txn) => new Transaction({ ...txn, note }))
+        return await algorand.account.getSigner(sender)(mutated, indexes)
+      }
+
+      const composer = algorand.newGroup()
+      composer.addPayment({
+        sender,
+        receiver: sender,
+        amount: AlgoAmount.MicroAlgo(1000),
+        signer: mutatingSigner,
+      })
+
+      const result = await composer.send()
+
+      expect(result.transactions[0].note).toEqual(note)
+      expect(result.txIds[0]).not.toBe(builtTxId)
+      expect(result.txIds[0]).toBe(result.transactions[0].txId())
+      expect(result.confirmations).toHaveLength(1)
+      expect(result.confirmations[0].txn.txn.txId()).toBe(result.txIds[0])
+    })
+
+    test('should use the mutated transactions when waiting for confirmation of a group', async () => {
+      const { algorand, context } = fixture
+      const sender = context.testAccount
+      const note = new TextEncoder().encode('mutated by the wallet')
+
+      let builtTxIds: string[] = []
+      let builtGroupId: string | undefined
+      const mutatingSigner: TransactionSigner = async (group, indexes) => {
+        builtTxIds = group.map((txn) => txn.txId())
+        builtGroupId = Buffer.from(group[0].group!).toString('base64')
+        // A wallet that mutates a grouped transaction must regroup, as the group ID no longer matches
+        const mutated = groupTransactions(group.map((txn) => new Transaction({ ...txn, note, group: undefined })))
+        return await algorand.account.getSigner(sender)(mutated, indexes)
+      }
+
+      const composer = algorand.newGroup()
+      composer.addPayment({
+        sender,
+        receiver: sender,
+        amount: AlgoAmount.MicroAlgo(1000),
+        signer: mutatingSigner,
+      })
+      composer.addPayment({
+        sender,
+        receiver: sender,
+        amount: AlgoAmount.MicroAlgo(2000),
+        signer: mutatingSigner,
+      })
+
+      const result = await composer.send()
+
+      expect(result.txIds).toHaveLength(2)
+      expect(result.txIds).not.toEqual(builtTxIds)
+      expect(result.txIds).toEqual(result.transactions.map((txn) => txn.txId()))
+      expect(result.groupId).not.toBe(builtGroupId)
+      expect(result.groupId).toBe(Buffer.from(result.transactions[0].group!).toString('base64'))
+      expect(result.confirmations.map((c) => c.txn.txn.txId())).toEqual(result.txIds)
+    })
+
+    test('should report the mutated transaction IDs from simulate', async () => {
+      const { algorand, context } = fixture
+      const sender = context.testAccount
+      const note = new TextEncoder().encode('mutated by the wallet')
+
+      let builtTxId: string | undefined
+      const mutatingSigner: TransactionSigner = async (group, indexes) => {
+        builtTxId = group[0].txId()
+        const mutated = group.map((txn) => new Transaction({ ...txn, note }))
+        return await algorand.account.getSigner(sender)(mutated, indexes)
+      }
+
+      const composer = algorand.newGroup()
+      composer.addPayment({
+        sender,
+        receiver: sender,
+        amount: AlgoAmount.MicroAlgo(1000),
+        signer: mutatingSigner,
+      })
+
+      const result = await composer.simulate()
+
+      expect(result.transactions[0].note).toEqual(note)
+      expect(result.txIds[0]).not.toBe(builtTxId)
+      expect(result.txIds[0]).toBe(result.transactions[0].txId())
     })
   })
 

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1835,7 +1835,10 @@ export class TransactionComposer {
         throw new Error('No transactions available')
       }
 
-      const transactionsToSend = this.transactionsWithSigners.map((stxn) => stxn.txn)
+      const transactionsToSend = resolveSignedTransactions(
+        this.transactionsWithSigners.map((t) => t.txn),
+        this.signedTransactions,
+      )
       const transactionIds = transactionsToSend.map((txn) => txn.txId())
 
       if (transactionsToSend.length > 1) {
@@ -1862,14 +1865,14 @@ export class TransactionComposer {
         })
       }
 
-      const group = this.transactionsWithSigners[0].txn.group
+      const group = transactionsToSend[0].group
 
       let waitRounds = params?.maxRoundsToWaitForConfirmation
 
       if (waitRounds === undefined) {
         const suggestedParams = await this.getSuggestedParams()
         const firstRound = suggestedParams.firstValid
-        const lastRound = this.transactionsWithSigners.reduce((max, txn) => (txn.txn.lastValid > max ? txn.txn.lastValid : max), 0n)
+        const lastRound = transactionsToSend.reduce((max, txn) => (txn.lastValid > max ? txn.lastValid : max), 0n)
         waitRounds = Number(lastRound - firstRound) + 1
       }
 
@@ -1915,6 +1918,13 @@ export class TransactionComposer {
       let sentTransactions: Transaction[] | undefined
       if (this.transactionsWithSigners) {
         sentTransactions = this.transactionsWithSigners.map((t) => t.txn)
+        if (this.signedTransactions?.length) {
+          // Reflect any mutations made by the signers, so the traces below are of what was actually sent
+          try {
+            sentTransactions = resolveSignedTransactions(sentTransactions, this.signedTransactions)
+            // eslint-disable-next-line no-empty
+          } catch {}
+        }
       } else if (this.rawBuildTransactions) {
         sentTransactions = this.rawBuildTransactions.length > 1 ? groupTransactions(this.rawBuildTransactions) : this.rawBuildTransactions
       }
@@ -2034,9 +2044,12 @@ export class TransactionComposer {
       }))
     }
 
-    const transactions = transactionsWithSigner.map((e) => e.txn)
     const encodedSignedTransactions = await this.signTransactions(transactionsWithSigner)
     const signedTransactions = decodeSignedTransactions(encodedSignedTransactions)
+    const transactions = resolveSignedTransactions(
+      transactionsWithSigner.map((e) => e.txn),
+      encodedSignedTransactions,
+    )
 
     const simulateRequest = {
       txnGroups: [
@@ -2187,6 +2200,22 @@ export class TransactionComposer {
       this.txns[index].data.maxFee = new AlgoAmount({ microAlgos: maxFee.microAlgos })
     })
   }
+}
+
+/**
+ * Resolve the transactions as they were signed.
+ *
+ * Signers (e.g. wallets) are allowed to mutate the transactions they are given, so the signed transactions are the
+ * source of truth for what is actually sent to the network. Without this, a mutated transaction would be reported
+ * (and waited for) under the transaction ID of the transaction that was built, which was never sent.
+ *
+ * The built transaction is returned when it wasn't mutated, since decoding is lossy for zero valued fields.
+ */
+function resolveSignedTransactions(builtTransactions: Transaction[], encodedSignedTransactions: Uint8Array[]): Transaction[] {
+  return decodeSignedTransactions(encodedSignedTransactions).map(({ txn }, index) => {
+    const builtTransaction = builtTransactions[index]
+    return builtTransaction !== undefined && builtTransaction.txId() === txn.txId() ? builtTransaction : txn
+  })
 }
 
 /** Get the logical maximum fee based on staticFee and maxFee */


### PR DESCRIPTION
## Proposed Changes

- Fixes `TransactionComposer.send()` hanging when a signer mutates the transactions it is given. Signers (e.g. wallets) can mutate what they sign, so the built transactions aren't necessarily the ones that reach the network. The mutated group was sent successfully, but `send()` then waited for confirmation of the pre-mutation transaction ID, which is never found.
- Resolves the transactions from the signed transactions instead, so `txIds`, `transactions`, `groupId` and the wait-round calculation all reflect what was actually sent. `simulate()` had the same stale `txIds` problem and is fixed alongside it.
- Keeps the built transaction when its ID is unchanged, as decoding is lossy for zero valued fields — a built `fee` of `0n` decodes back as `undefined`. Without this, the fee assertions in the inner transaction fee coverage tests regress.
- Prefers the signed transactions in the error path too, so debug traces are of what was really sent.
- Adds regression tests with a mutating signer covering a single transaction, a regrouped group of two, and `simulate()`. All three fail on `v10-backup` (the two send cases time out waiting for confirmation) and pass with the fix.

## Notes

This is on the v10 line, which should not affect many downstream consumers. One notable v10 user is Lora, which has an issue when keyregging for a Pera PQ account (common path via nodekit.) The mutated group is submitted but waiting for confirmation fails. 

`main` is not affected in the same way: it delegates to algosdk's `AtomicTransactionComposer`, whose `gatherSignatures()` already derives `txIDs` by decoding the signed transactions. It does have a related stale-ID issue in `sendAtomicTransactionComposer` and `simulate()`, but that is a separate codebase and out of scope here.
